### PR TITLE
Sql Endpoint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,9 @@
         "fmizzell/sae" : "dev-master",
         "fmizzell/datastore" : "dev-master",
         "fmizzell/json-schema-provider": "dev-master",
-	"fmizzell/harvest": "dev-master",
+        "fmizzell/harvest": "dev-master",
+        "fmizzell/maquina": "dev-master",
+        "twig/twig": "1.35.4",
         "guzzlehttp/guzzle" : "6.3"
     },
     "require-dev": {

--- a/modules/custom/dkan_datastore/dkan_datastore.routing.yml
+++ b/modules/custom/dkan_datastore/dkan_datastore.routing.yml
@@ -1,8 +1,8 @@
 dkan_datastore.datastore_query:
-  path: '/api/v1/datastore/{queryStr}'
+  path: '/api/v1/sql/{queryStr}'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\dkan_api\Controller\Datastore::runQuery'}
+    { _controller: '\Drupal\dkan_datastore\Controller\Datastore::runQuery'}
   requirements:
     _access: 'TRUE'
 

--- a/modules/custom/dkan_datastore/dkan_datastore.routing.yml
+++ b/modules/custom/dkan_datastore/dkan_datastore.routing.yml
@@ -1,0 +1,8 @@
+dkan_datastore.datastore_query:
+  path: '/api/v1/datastore/{queryStr}'
+  methods: [GET]
+  defaults:
+    { _controller: '\Drupal\dkan_api\Controller\Datastore::runQuery'}
+  requirements:
+    _access: 'TRUE'
+

--- a/modules/custom/dkan_datastore/src/Controller/Datastore.php
+++ b/modules/custom/dkan_datastore/src/Controller/Datastore.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\dkan_datastore\Controller;
+
+use Drupal\dkan_api\Controller\Api;
+//use Drupal\dkan_api\Storage\DrupalNodeDataset;
+//use Drupal\dkan_schema\SchemaRetriever;
+//use JsonSchemaProvider\Provider;
+
+class Datastore extends Api {
+
+  private $connection;
+
+  public function __construct() {
+    //$this->nodeDataset = new DrupalNodeDataset();
+  }
+
+  protected function getStorage() {
+    //return $this->nodeDataset;
+  }
+
+  public function runQuery($queryStr) {
+  $provider = new Provider(new SchemaRetriever());
+  return $provider->retrieve('dataset');
+}
+
+  protected function getJsonSchema() {
+    parent::getJsonSchema();
+  }
+
+  public function get($uuid) {
+    parent::get($uuid);
+  }
+
+  public function postAndGetAll() {
+    parent::postAndGetAll();
+  }
+
+  public function getEngine() {
+    parent::getEngine();
+  }
+
+}

--- a/modules/custom/dkan_datastore/src/Controller/Datastore.php
+++ b/modules/custom/dkan_datastore/src/Controller/Datastore.php
@@ -2,42 +2,82 @@
 
 namespace Drupal\dkan_datastore\Controller;
 
-use Drupal\dkan_api\Controller\Api;
-//use Drupal\dkan_api\Storage\DrupalNodeDataset;
-//use Drupal\dkan_schema\SchemaRetriever;
-//use JsonSchemaProvider\Provider;
+use Dkan\Datastore\Manager\IManager;
+use Dkan\Datastore\Resource;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Drupal\dkan_datastore\SqlParser;
 
-class Datastore extends Api {
-
-  private $connection;
-
-  public function __construct() {
-    //$this->nodeDataset = new DrupalNodeDataset();
-  }
-
-  protected function getStorage() {
-    //return $this->nodeDataset;
-  }
+class Datastore {
 
   public function runQuery($queryStr) {
-  $provider = new Provider(new SchemaRetriever());
-  return $provider->retrieve('dataset');
-}
+    if (SqlParser::validate($queryStr) === TRUE) {
+      $query_pieces = $this->explode($queryStr);
+      $select = array_shift($query_pieces);
+      $uuid = $this->getUuidFromSelect($select);
 
-  protected function getJsonSchema() {
-    parent::getJsonSchema();
+      try {
+        $manager = $this->getDatastoreManager($uuid);
+
+        /* @todo This is bad we should respect the levels of abstraction.
+         * The manager should not assume what the storage mechanism looks like
+         * and neither should we.
+         */
+
+        $table = $manager->getTableName();
+
+        $connection = \Drupal::database();
+
+        $query_string = "SELECT * FROM {$table} " . implode(" ", $query_pieces);
+
+        $query = $connection->query($query_string);
+        $result = $query->fetchAll();
+
+        return new JsonResponse($result);
+      }
+      catch (\Exception $e) {
+        return new JsonResponse("Invalid query string.");
+      }
+    }
+    else {
+      return new JsonResponse("Invalid query string.");
+    }
   }
 
-  public function get($uuid) {
-    parent::get($uuid);
+  private function explode(string $queryStr) {
+    $pieces =  explode("]", $queryStr);
+    foreach ($pieces as $key => $piece) {
+      $pieces[$key] = str_replace("[", "", $piece);
+      if (substr_count($pieces[$key], "ORDER BY") > 0) {
+        $pieces[$key] .= " ASC";
+      }
+    }
+    array_pop($pieces);
+    return $pieces;
   }
 
-  public function postAndGetAll() {
-    parent::postAndGetAll();
+  private function getUuidFromSelect(string $select) {
+    $pieces = explode("FROM", $select);
+    return trim(end($pieces));
   }
 
-  public function getEngine() {
-    parent::getEngine();
+  private function getDatastoreManager($uuid) : IManager {
+    $database = \Drupal::service('dkan_datastore.database');
+
+    $dataset = \Drupal::entityManager()->loadEntityByUuid('node', $uuid);
+
+    $metadata = json_decode($dataset->field_json_metadata->value);
+    $resource = new Resource($dataset->id(), $metadata->distribution[0]->downloadURL);
+
+    $provider = new \Dkan\Datastore\Manager\InfoProvider();
+    $provider->addInfo(new \Dkan\Datastore\Manager\Info(SimpleImport::class, "simple_import", "SimpleImport"));
+
+    $bin_storage = new \Dkan\Datastore\LockableBinStorage("dkan_datastore", new \Dkan\Datastore\Locker("dkan_datastore"), new \Drupal\dkan_datastore\Storage\Variable());
+    $factory = new \Dkan\Datastore\Manager\Factory($resource, $provider, $bin_storage, $database);
+
+    return  $factory->get();
+
   }
+
+
 
 }

--- a/modules/custom/dkan_datastore/src/SqlParser.php
+++ b/modules/custom/dkan_datastore/src/SqlParser.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Drupal\dkan_datastore;
+
+use Maquina\StateMachine\MachineOfMachines;
+use Maquina\Builder as mb;
+use Maquina\Feeder;
+
+class SqlParser
+{
+  public static function validate(string $sql): bool {
+    $machine = self::getMachine();
+    try {
+      Feeder::feed($sql, $machine);
+      return TRUE;
+    }
+    catch (\Exception $e) {
+      return FALSE;
+    }
+  }
+
+  private static function getMachine() {
+
+    $machine = new MachineOfMachines('select_start');
+    $machine->addEndState("end");
+
+    $machine->addMachine('select', mb::s('SELECT * FROM'));
+    $machine->addMachine('select_var', mb::bh('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$_-',  mb::ONE_OR_MORE));
+    $machine->addMachine("where", self::getWhereMachine());
+    $machine->addMachine("order_by", self::getOrderByMachine());
+    $machine->addMachine("limit", self::getLimitMachine());
+
+
+    $machine->addTransition('select_start', ["["], "select");
+    $machine->addTransition('select', [" "], "select_var");
+    $machine->addTransition('select_var', ["]"], "select_end");
+    $machine->addTransition('select_end', [";"], "end");
+
+    $machine->addTransition('select_end', ["["], "where");
+    $machine->addTransition('where', ["]"], "where_end");
+    $machine->addTransition('where_end', [";"], "end");
+
+    $machine->addTransition('where_end', ["["], "order_by");
+    $machine->addTransition('order_by', ["]"], "order_by_end");
+    $machine->addTransition('order_by_end', [";"], "end");
+
+    $machine->addTransition('order_by_end', ["["], "limit");
+    $machine->addTransition('limit', ["]"], "limit_end");
+    $machine->addTransition('limit_end', [";"], "end");
+
+    return $machine;
+  }
+
+  private static function getWhereMachine() {
+    $machine = new MachineOfMachines('where');
+    $machine->addEndState("quoted_string");
+
+    $machine->addMachine('where', mb::s('WHERE'));
+    $machine->addMachine('where_var', mb::bh('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$_',  mb::ONE_OR_MORE));
+    $machine->addMachine("equal", mb::s("LIKE"));
+    $machine->addMachine("quoted_string", self::getQuotedStringMachine());
+    $machine->addMachine("and", mb::s("AND"));
+
+
+    $machine->addTransition('where', [" "], "where_var");
+    $machine->addTransition('where_var', [" "], "equal");
+    $machine->addTransition('equal', [" "], "quoted_string");
+    $machine->addTransition('quoted_string', [" "], "and");
+    $machine->addTransition('and', [" "], "where_var");
+
+    return $machine;
+  }
+
+  private static function getQuotedStringMachine() {
+    $machine = new MachineOfMachines('1');
+    $machine->addEndState("end");
+
+    $machine->addMachine('string', mb::bh('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ %$.',  mb::ONE_OR_MORE));
+
+    $machine->addTransition('1', ["'"], "string");
+    $machine->addTransition('string', ["'"], "end");
+
+    return $machine;
+  }
+
+  private static function getOrderByMachine() {
+    $machine = new MachineOfMachines('order');
+    $machine->addEndState("order_var");
+
+    $machine->addMachine('order', mb::s('ORDER BY'));
+    $machine->addMachine('order_var', mb::bh('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$_',  mb::ONE_OR_MORE));
+
+    $machine->addTransition('order', [" "], "order_var");
+    $machine->addTransition('order_var', [","], "space");
+    $machine->addTransition('space', [" "], "order_var");
+
+    return $machine;
+  }
+
+  private static function getLimitMachine() {
+    $machine = new MachineOfMachines('limit');
+    $machine->addEndState("numeric1");
+    $machine->addEndState("numeric2");
+
+    $machine->addMachine('limit', mb::s('LIMIT'));
+    $machine->addMachine('offset', mb::s('OFFSET'));
+    $machine->addMachine('numeric1', mb::bh('0123456789'));
+    $machine->addMachine('numeric2', mb::bh('0123456789'));
+
+    $machine->addTransition('limit', [" "], "numeric1");
+    $machine->addTransition('numeric1', [" "], "offset");
+    $machine->addTransition('offset', [" "], "numeric2");
+
+    return $machine;
+  }
+
+}

--- a/modules/custom/dkan_datastore/src/Storage/DatastoreQuery.php
+++ b/modules/custom/dkan_datastore/src/Storage/DatastoreQuery.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Drupal\dkan_api\Storage;
+
+use Drupal\node\Entity\Node;
+use Contracts\Storage;
+use Contracts\BulkRetriever;
+
+/*class DrupalNodeDataset implements Storage, BulkRetriever {
+  protected function getType() {
+    return 'dataset';
+  }
+
+  public function retrieve(string $id): ?string {
+
+    foreach ($this->getNodesByUuid($id) as $result) {
+      $node = Node::load($result->nid);
+      return $node->field_json_metadata->value;
+    }
+
+    throw new \Exception("No data with the identifier {$id} was found.");
+  }
+
+  public function retrieveAll(): array {
+    $connection = \Drupal::database();
+    $sql = "SELECT nid FROM node WHERE type = :type";
+    $query = $connection->query($sql, [':type' => $this->getType()]);
+    $results = $query->fetchAll();
+
+    $all = [];
+    foreach ($results as $result) {
+      $node = Node::load($result->nid);
+      $all[] = $node->field_json_metadata->value;
+    }
+    return $all;
+  }
+
+  public function remove(string $id) {
+
+    foreach ($this->getNodesByUuid($id) as $result) {
+      $node = Node::load($result->nid);
+      return $node->delete();
+    }
+  }
+
+  public function store(string $data, string $id = NULL): string {
+
+    $data = json_decode($data);
+
+    if (!$id && isset($data->identifier)) {
+        $id = $data->identifier;
+    }
+
+    if ($id) {
+        $node = \Drupal::service('entity.repository')->loadEntityByUuid('node', $id);
+    }
+
+    if ($node) {    // update existing node
+      $node->field_json_metadata = json_encode($data);
+      $node->save();
+      return $node->id();
+    } else {    // create new node
+      $title = isset($data->title) ? $data->title : $data->name;
+      $nodeWrapper = NODE::create([
+        'title' => $title,
+        'type' => 'dataset',
+        'uuid' => $id,
+        'field_json_metadata' => json_encode($data)
+      ]);
+      $nodeWrapper->save();
+      return $nodeWrapper->id();
+    }
+
+    return NULL;
+  }
+
+  private function getNodesByUuid($uuid) {
+    $connection = \Drupal::database();
+    $sql = "SELECT nid FROM node WHERE uuid = :uuid AND type = :type";
+    $query = $connection->query($sql, [':uuid' => $uuid, ':type' => $this->getType()]);
+    return $query->fetchAll();
+  }*/
+
+  use Contracts\Sorter;
+  use Contracts\Conditioner;
+  use Contracts\Offsetter;
+  use Contracts\Limiter;
+
+class DatastoreQuery extends Memory implements Sorter, Conditioner, Offsetter, Limiter
+{
+  private $offset = 0;
+  private $limit = 0;
+
+  private $sorts = [
+    'ascend' => [],
+    'descend' => [],
+  ];
+
+  private $conditions = [];
+
+  public function retrieveAll(): array
+  {
+    $results = parent::retrieveAll();
+    $results = $this->applyFilters($results);
+    $this->resetFilters();
+    return  $results;
+  }
+
+  public function store(string $data, string $id = NULL): string
+  {
+    $this->validate($data);
+    return parent::store($data, $id);
+  }
+
+  public function conditionByIsEqualTo(string $property, string $value)
+  {
+    $this->conditions[$property][] = $value;
+  }
+
+  public function limitTo(int $number_of_items)
+  {
+    $this->limit = $number_of_items;
+  }
+
+  public function offsetBy(int $offset)
+  {
+    $this->offset = $offset;
+  }
+
+  public function sortByAscending(string $property)
+  {
+    $this->sorts['ascend'][] = $property;
+  }
+
+  public function sortByDescending(string $property)
+  {
+    $this->sorts['descend'][] = $property;
+  }
+
+  private function applyFilters(array $results) {
+
+    if (!empty($this->conditions)) {
+      $results2 = [];
+
+      foreach ($this->conditions as $property => $values) {
+        foreach ($values as $value) {
+          foreach ($results as $key => $result) {
+            $obj = json_decode($result);
+            if ($obj->{$property} == $value) {
+              $results2[$key] = $result;
+            }
+          }
+        }
+      }
+
+      $results = $results2;
+    }
+
+
+    foreach ($this->sorts as $type => $properties) {
+      foreach ($properties as $property) {
+        usort($results, function ($a, $b) use ($property) {
+          return $this->compare($a, $b, $property);
+        });
+
+        if ($type == 'descend') {
+          $results = array_reverse($results);
+        }
+      }
+    }
+
+    if ($this->limit > 0 || $this->offset > 0) {
+      $results = array_slice($results, $this->offset, $this->limit);
+    }
+
+    return $results;
+  }
+
+  private function resetFilters() {
+    $this->offset = 0;
+    $this->limit = 0;
+
+    $this->sorts = [
+      'ascend' => [],
+      'descend' => [],
+    ];
+
+    $this->conditions = [];
+  }
+
+  private function validate(string $data) {
+    $decoded = json_decode($data);
+    if (is_null($decoded)) {
+      throw new \Exception("Only JSON strings can be stored");
+    }
+    if (!is_object($decoded)) {
+      throw new \Exception("Only strings with JSON objects can be stored");
+    }
+  }
+
+}


### PR DESCRIPTION
* QA *

1. Get a local sandbox of dkan working
2. Bring in the dummy content: `dktl drush dkan-dummy-content:create`
3. Bing a dataset into the datastore: `dktl drush dkan-datastore:import 1f2042ad-c513-4fcf-a933-cae6c6fd35e6`
4. Play with the endpoint

Here is an endpoint calls that should work:
http://dkan/api/v1/sql/[SELECT%20*%20FROM%201f2042ad-c513-4fcf-a933-cae6c6fd35e6][WHERE%20code%20LIKE%20'A%25'%20AND%20tax_rate%20LIKE%20'%25'][ORDER%20BY%20tax_rate,%20name][LIMIT%202%20OFFSET%201];

Any subsets of that query should also work. By a subset I mean that you can remove an brackets block ([...]) from right to left and you should still get results.

The blocks work in order from left to right, so you need the previous block. For example to use an ORDER BY block, you need a WHERE block.

The sql that is available is fairly restrictive. Here are some of the restrictions:

1. You can not filter columns, currently on `SELECT *` works.
2. WHERE clauses only support the the LIKE operator
3. As you can see ORDER BY does not use ASC or DESC, adding that would break the query. Right now the endpoint assumes ASC. 
4. Queries have to end with a semicolon after the closing bracket.
5 Spacing is really important `[ORDER BY a, b]` works, but [ORDER BY a,b] does not.
