### PR TITLE
Add config for Administrator role

### DIFF
--- a/config/install/user.role.administrator.yml
+++ b/config/install/user.role.administrator.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: administrator
+label: Administrator
+weight: 3
+is_admin: true
+permissions: {  }


### PR DESCRIPTION
Noticed `dkan2.install` refers to an Administrator role and assigns it to UID 1, though no such role exists. This PR adds it via config.

<img width="1310" alt="Screen Shot 2019-04-29 at 8 49 54 AM" src="https://user-images.githubusercontent.com/729791/56911203-3d0aca00-6a61-11e9-8fcb-fc5c0de3314b.png">
