### PR TITLE
Harvest transform file importer

### DIFF
--- a/modules/custom/dkan_harvest/src/Load/FileHelper.php
+++ b/modules/custom/dkan_harvest/src/Load/FileHelper.php
@@ -9,11 +9,11 @@ class FileHelper implements IFileHelper {
   }
 
   public function retrieveFile($url, $destination = NULL, $managed = FALSE) {
-    system_retrieve_file($url, $destination, $managed, FILE_EXISTS_REPLACE);
+    return system_retrieve_file($url, $destination, $managed, FILE_EXISTS_REPLACE);
   }
 
   public function fileCreate($uri) {
-    file_create_url($uri);
+    return file_create_url($uri);
   }
 
   public function defaultSchemeDirectory() {

--- a/modules/custom/dkan_harvest/src/Transform/ResourceImporter.php
+++ b/modules/custom/dkan_harvest/src/Transform/ResourceImporter.php
@@ -49,7 +49,7 @@ class ResourceImporter extends Transform {
    */
   protected function updateDistributions($dataset) {
     // Abort if there's no distributions.
-    if (empty($dataset)) {
+    if (empty($dataset->distribution)) {
       return $dataset;
     }
 

--- a/modules/custom/dkan_harvest/src/Transform/ResourceImporter.php
+++ b/modules/custom/dkan_harvest/src/Transform/ResourceImporter.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\dkan_harvest\Transform;
+
+use Harvest\Transform\Transform;
+use Drupal\dkan_harvest\Load\FileHelper;
+
+/**
+ * Defines a transform that saves the resources from a dataset.
+ */
+class ResourceImporter extends Transform {
+
+  /**
+   * The file helper object.
+   *
+   * @var Drupal\dkan_harvest\Load\FileHelper
+   */
+  protected $fileHelper;
+
+  /**
+   * ResourceImporter constructor.
+   *
+   * @param object $harvest_plan
+   *   JSON decoded harvest plan.
+   */
+  public function __construct($harvest_plan) {
+    parent::__construct($harvest_plan);
+    $this->fileHelper = new FileHelper();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function run(&$items) {
+    foreach ($items as $key => $item) {
+      foreach ($item->distribution as $index => $dist) {
+        if (isset($dist->downloadURL)) {
+          // Attempt to save a resource file locally.
+          $file_path = $this->saveFile($dist->downloadURL, $item->identifier);
+          if ($file_path) {
+            // Update resource URL.
+            $items[$key]->distribution[$index]->downloadURL = $file_path;
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Pulls down external file and saves it locally.
+   *
+   * If this method is called when PHP is running on the CLI (e.g. via drush),
+   * `$settings['file_public_base_url']` must be configured in `settings.php`,
+   * otherwise 'default' will be used as the hostname in the new URL.
+   *
+   * @param string $url
+   *   External file URL.
+   * @param string $dataset_id
+   *   Dataset identifier used to group resources together.
+   *
+   * @return string|bool
+   *   The URL for the newly created file, or FALSE if failure occurs.
+   */
+   public function saveFile($url, $dataset_id) {
+
+    $targetDir = 'public://distribution/' . $dataset_id;
+    $this->fileHelper->prepareDir($targetDir);
+
+    // Abort if file can't be saved locally.
+    if (!$path = $this->fileHelper->retrieveFile($url, $targetDir)) {
+      return FALSE;
+    }
+
+    return $this->fileHelper->fileCreate($path);
+  }
+
+}

--- a/modules/custom/dkan_harvest/tests/src/Unit/Transform/ResourceImporterTest.php
+++ b/modules/custom/dkan_harvest/tests/src/Unit/Transform/ResourceImporterTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Drupal\Tests\dkan_harvest\Unit\Transform;
+
+use Dkan\PhpUnit\DkanTestBase;
+use Drupal\dkan_harvest\Transform\ResourceImporter;
+use Drupal\dkan_harvest\Load\IFileHelper;
+
+/**
+ * @group dkan
+ */
+class ResourceImporterTest extends DkanTestBase {
+
+  /**
+   * Data provider for testSaveFile.
+   *
+   * @return array Array of arguments.
+   */
+  public function dataTestSaveFile() {
+    return [
+      ["http://example.com/data1.csv", "data1.csv", TRUE, 'dsid', "http://localhost/site/default/files/distribution/dsid/data1.csv"],
+      ["http://example.com/data2.csv", "data2.csv", FALSE, 'dsid', FALSE], // Pass
+    ];
+  }
+
+  /**
+   * Tests the ResourceImporter::saveFile() method.
+   *
+   * @dataProvider dataTestSaveFile
+   *
+   * @param string $url
+   * @param string $filename
+   * @param bool $isUrlValid
+   * @param string $datasetId
+   * @param string $expected
+   */
+  public function testSaveFile($url, $filename, $isUrlValid, $datasetId, $expected) {
+    // Set up.
+    $fileHelperStub = $this->createMock(IFileHelper::class);
+    $fileHelperStub->method('prepareDir')
+      ->willReturn(TRUE);
+    $fileHelperStub->method('retrieveFile')
+      ->willReturn($isUrlValid);
+    $fileHelperStub->method('fileCreate')
+      ->willReturn("http://localhost/site/default/files/distribution/$datasetId/$filename");
+
+    $resourceImporterStub = $this->getMockBuilder(ResourceImporter::class)
+      ->setMethods(NULL)
+      ->disableOriginalConstructor()
+      ->getMock();
+    $this->writeProtectedProperty($resourceImporterStub, 'fileHelper', $fileHelperStub);
+
+    // Assert.
+    $actual = $resourceImporterStub->saveFile($url, $datasetId);
+    $this->assertEquals($expected, $actual);
+  }
+
+}

--- a/modules/custom/dkan_harvest/tests/src/Unit/Transform/ResourceImporterTest.php
+++ b/modules/custom/dkan_harvest/tests/src/Unit/Transform/ResourceImporterTest.php
@@ -17,6 +17,7 @@ class ResourceImporterTest extends DkanTestBase {
    * @return array
    */
   public function dataTestRun() {
+
     $datasetJson = <<<EOF
 {
   "accessLevel": "public",
@@ -66,10 +67,8 @@ EOF;
     $resourceImporterStub->method('updateDistributions')
       ->willReturn($modifiedDataset);
 
-    // Execute 'run' method.
-    $resourceImporterStub->run($datasets);
-
     // Assert
+    $resourceImporterStub->run($datasets);
     $this->assertEquals($expected, $datasets[0]->distribution[0]->downloadURL);
 
   }
@@ -80,6 +79,7 @@ EOF;
    * @return array
    */
   public function dataTestUpdateDistributions() {
+
     $datasetJson = <<<EOF
 {
   "accessLevel": "public",
@@ -129,10 +129,9 @@ EOF;
     $resourceImporterStub->method('updateDownloadUrl')
       ->willReturn($dist);
 
-    $updatedDataset = $this->invokeProtectedMethod($resourceImporterStub, 'updateDistributions', $dataset);
-
     // Assert
-    $this->assertEquals($expected, $updatedDataset->distribution[0]->downloadURL);
+    $actualDataset = $this->invokeProtectedMethod($resourceImporterStub, 'updateDistributions', $dataset);
+    $this->assertEquals($expected, $actualDataset->distribution[0]->downloadURL);
 
   }
 
@@ -142,6 +141,7 @@ EOF;
    * @return array
    */
   public function dataTestUpdateDownloadUrl() {
+
     $datasetJson = <<<EOF
 {
   "accessLevel": "public",
@@ -189,10 +189,9 @@ EOF;
     $resourceImporterStub->method('saveFile')
       ->willReturn($url);
 
-    $updatedDist = $this->invokeProtectedMethod($resourceImporterStub, 'updateDownloadUrl', $dataset, $dist);
-
     // Assert
-    $this->assertEquals($expected, $updatedDist->downloadURL);
+    $actualDist = $this->invokeProtectedMethod($resourceImporterStub, 'updateDownloadUrl', $dataset, $dist);
+    $this->assertEquals($expected, $actualDist->downloadURL);
 
   }
 
@@ -202,10 +201,12 @@ EOF;
    * @return array Array of arguments.
    */
   public function dataTestSaveFile() {
+
     return [
-      ["http://example.com/data1.csv", "data1.csv", TRUE, 'dsid', "http://localhost/site/default/files/distribution/dsid/data1.csv"],
-      ["http://example.com/data2.csv", "data2.csv", FALSE, 'dsid', FALSE], // Pass
+      ["data1.csv", "testid1", TRUE, "http://localhost/site/default/files/distribution/testid1/data1.csv"],
+      ["data2.csv", "testid2", FALSE, FALSE],
     ];
+
   }
 
   /**
@@ -213,13 +214,13 @@ EOF;
    *
    * @dataProvider dataTestSaveFile
    *
-   * @param string $url
    * @param string $filename
-   * @param bool $isUrlValid
    * @param string $datasetId
+   * @param bool $isUrlValid
    * @param string $expected
    */
-  public function testSaveFile($url, $filename, $isUrlValid, $datasetId, $expected) {
+  public function testSaveFile($filename, $datasetId, $isUrlValid, $expected) {
+
     // Create FileHelper stub.
     $fileHelperStub = $this->createMock(IFileHelper::class);
     $fileHelperStub->method('prepareDir')
@@ -237,8 +238,9 @@ EOF;
     $this->writeProtectedProperty($resourceImporterStub, 'fileHelper', $fileHelperStub);
 
     // Assert.
-    $actual = $resourceImporterStub->saveFile($url, $datasetId);
+    $actual = $resourceImporterStub->saveFile("http://example.com/dist/$filename", $datasetId);
     $this->assertEquals($expected, $actual);
+
   }
 
 }


### PR DESCRIPTION
#80
`ResourceImporter.php` is a new harvest transform that saves external distribution files locally. This implementation makes the following assumptions:
1. Distribution files should be saved under `public://distribution/[dataset-identifier]/[filename-and-extension]`, where the filename and extension are extracted from the `downloadURL` distribution property.
2. Download URLs should contain a file name and extension in their path (e.g. http://example.com/path/to/file.csv).

Note:
If using this harvest transform via the CLI (e.g. drush), you'll want to configure the `file_public_base_url` in `settings.php` as shown below (otherwise `default` will be used as the host):
```
if (PHP_SAPI == "cli") {
  $settings['file_public_base_url'] = "http://dkan/sites/default/files";
}
```