### PR TITLE
Adds Lunr Search Backend

### DIFF
--- a/modules/custom/interra_api/lunr.php/ReadMe.MD
+++ b/modules/custom/interra_api/lunr.php/ReadMe.MD
@@ -1,0 +1,54 @@
+# Lunr Index Generator for PHP
+
+This project creates an index for Lunr.js in PHP. This will allow you to generate a Lunr.js endpoint in a PHP application.
+
+## Installation
+
+``composer install``
+
+## Tests
+
+Coming soon.
+
+## Usage
+
+Generating an index is similar to Lunr.js.
+
+```php
+
+  // Instantiate the builder.
+  $build = new BuildLunrIndex();
+  // Add a unique id.
+  $build->ref('identifier');
+  // Add fields.
+  $build->field("title");
+  $build->field("description");
+  // Add transforms to the pipeline.
+  $build->addPipeline('trimmer');
+  $build->addPipeline('stop_word_filter');
+  $build->addPipeline('stemmer');
+  // Load docs.
+  $string = file_get_contents("./fixtures/fixture.json");
+  $datasets = json_decode($string, true);
+  // Add documents to the index.
+  foreach ($datasets as $dataset) {
+    $build->add($dataset);
+  }
+
+  // Output the index.
+  $output = $build->output();
+
+  // Place wherever.
+  echo json_encode($output, JSON_PRETTY_PRINT);
+
+
+```
+
+## Pipelines
+
+There is a simple Pipelines class to run transforms on the terms during indexing. See ``src/pipelines.php`` for included pipelines.
+
+
+## Missing Features
+
+This index is missing boosts and several other indexing features.

--- a/modules/custom/interra_api/lunr.php/composer.json
+++ b/modules/custom/interra_api/lunr.php/composer.json
@@ -1,0 +1,7 @@
+{
+    "name": "partisan/lunrtest",
+    "require": {
+        "markfullmer/porter2": "^1.0",
+        "phpunit/phpunit": "^8.2"
+    }
+}

--- a/modules/custom/interra_api/lunr.php/demo.php
+++ b/modules/custom/interra_api/lunr.php/demo.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * Demos for index builder.
+ */
+
+include('./src/BuildLunrIndex.php');
+include('./src/Pipeline.php');
+include('./src/pipelines.php');
+
+// Shows pipeline.
+$tokens = ["one", "two ", "the", "three", '$five', "description",];
+$pipeline = new Pipeline();
+$pipeline->add('trimmer');
+$pipeline->add('stop_word_filter');
+$pipeline->add('stemmer');
+$results = $pipeline->run($tokens);
+var_dump($results);
+
+// Shows building index.
+$build = new BuildLunrIndex();
+$build->ref('identifier');
+$build->field("title");
+$build->field("description");
+$build->addPipeline('trimmer');
+$build->addPipeline('stop_word_filter');
+$build->addPipeline('stemmer');
+$string = file_get_contents("./fixtures/fixture.json");
+$datasets = json_decode($string, true);
+
+foreach ($datasets as $dataset) {
+  $build->add($dataset);
+}
+
+$output = $build->output();
+echo json_encode($output, JSON_PRETTY_PRINT);

--- a/modules/custom/interra_api/lunr.php/fixtures/fixture.json
+++ b/modules/custom/interra_api/lunr.php/fixtures/fixture.json
@@ -1,0 +1,17 @@
+[
+  {
+  	"title": "one title rule all",
+  	"description": "this description brown red blue cow fox bird",
+  	"identifier": "id1"
+  },
+  {
+  	"title": "one title bind them",
+  	"description": "description fox bird",
+  	"identifier": "id2"
+  },
+  {
+  	"title": "one title find them",
+  	"description": "title blue rule all three blue",
+  	"identifier": "id3"
+  }
+]

--- a/modules/custom/interra_api/lunr.php/src/BuildLunrIndex.php
+++ b/modules/custom/interra_api/lunr.php/src/BuildLunrIndex.php
@@ -1,0 +1,224 @@
+<?php
+
+class BuildLunrIndex {
+
+  private $version = "2.3.6";
+
+  public function __construct() {
+    $this->fields = [];
+    $this->fieldVectors = [];
+    $this->invertedIndex = [];
+    $this->pipelines = [];
+    $this->ref = "";
+    $this->termIndex = 0;
+    $this->fieldTermFrequencies = [];
+    $this->fieldLengths = [];
+    $this->pipeline = new Pipeline();
+    $this->_b = 0.75;
+    $this->_k1 = 1.2;
+    $this->documentCount = 0;
+    $this->averageFieldLength = [];
+  }
+
+  public function add($doc) {
+    $id = $doc[$this->ref];
+    $this->documentCount++;
+
+    foreach ($this->fields as $field) {
+      if (isset($doc[$field]) && $doc[$field]) {
+        $terms = $this->getTerms($doc[$field]);
+        $terms = $this->runPipeline($terms);
+        $fieldRef = "$field/$id";
+
+        $this->fieldLengths[$fieldRef] = count($terms);
+        $fieldTerms = [];
+        foreach ($terms as $term) {
+          if (!isset($fieldTerms[$term])) {
+            $fieldTerms[$term] = 1;
+          }
+          else {
+            $fieldTerms[$term]++;
+          }
+          $i = $this->getTermInIndex($term, $this->invertedIndex, TRUE);
+          // Term exists in index.
+          if ($i || $i === 0) {
+            $entry = $this->invertedIndex[$i];
+            // Field already added to index.
+            if (isset($entry[1]->{$field})) {
+              $entry[1]->{$field}->{$id} = new stdClass;
+            }
+            // Add field to index.
+            else {
+              $entry[1]->{$field} = (object)[$id => new stdClass];
+            }
+            $entry[1]->{$field}->{$id} = new stdClass;
+            $this->invertedIndex[$i] = $entry;
+          }
+          // Term needs to be added to the index.
+          else {
+            $idEntry = (object)[$id => new stdClass];
+            $fieldEntry = $this->newFieldEntry($term, $this->fields, $field, $this->termIndex, $id);
+            $this->invertedIndex[] = $fieldEntry;
+            $this->termIndex++;
+          }
+        }
+        $this->fieldTermFrequencies[$fieldRef] = $fieldTerms;
+
+      }
+    }
+  }
+
+  /**
+   * Creates a new entry. Casts to object in order to create json output in
+   * same formats as Lunr.js.
+   */
+  private function newFieldEntry(string $term, array $fields, string $field, int $termIndex, string $identifier) {
+    $fieldEntries = ["_index" => $this->termIndex];
+    foreach ($fields as $fi) {
+      if ($field === $fi) {
+        $id = (object)[$identifier => new stdClass];
+        $fieldEntries[$fi] = $id;
+      }
+      else {
+        $fieldEntries[$fi] = new stdClass;
+      }
+    }
+    return [$term, (object)$fieldEntries];
+  }
+
+  private function getTermInIndex($term, $index, $id = FALSE) {
+    $i = 0;
+    foreach ($index as $entry) {
+      if ($term === $entry[0]) {
+        if ($id) {
+          return $i;
+        }
+        else {
+          return $entry;
+        }
+      }
+      $i++;
+    }
+    return FALSE;
+  }
+
+  public function getTerms($string) {
+    $string = preg_replace("/[^A-Za-z0-9 ]/", '', $string);
+    return explode(" ", $string);
+  }
+
+  public function ref($ref) {
+    $this->ref = $ref;
+  }
+
+  public function field($field) {
+    $this->fields[] = $field;
+  }
+
+  public function addPipeline(string $pipeline) {
+    $this->pipelines[] = $pipeline;
+  }
+
+  private function runPipeline(array $terms) {
+    if ($this->pipelines) {
+      foreach($this->pipelines as $indexPipeline) {
+        $this->pipeline->add($indexPipeline);
+      }
+      $terms = $this->pipeline->run($terms);
+    }
+    return $terms;
+  }
+
+  private function calculateAverageFieldLengths() {
+    $documentsWithField = [];
+    $accumulator = [];
+    $totaller = [];
+    foreach ($this->fieldLengths as $fieldRef => $fieldLength) {
+      $i = explode("/", $fieldRef);
+      $field = $i[0];
+      $identifier = $i[1];
+      isset($documentsWithField[$field]) ? $documentsWithField[$field]++ : $documentsWithField[$field] = 1;
+      $accumulator[$field] = isset($accumulator[$field]) ? $accumulator[$field] + $fieldLength : $fieldLength;
+    }
+    foreach ($this->fields as $field) {
+      $totaller[$field] = $accumulator[$field] / $documentsWithField[$field];
+    }
+    $this->averageFieldLength = $totaller;
+  }
+
+  /**
+   * Sorts alphabetically. Added as a static function to use usort() in a class.
+   */
+  private static function sortInvertedIndex($a, $b) {
+    return strcmp($a[0], $b[0]);
+  }
+
+  private function idf(array $entry, int $documentCount) {
+    $documentsWithTerm = 0;
+    foreach ($entry[1] as $fieldName => $items) {
+      if ($fieldName !== '_index') {
+        $documentsWithTerm = $documentsWithTerm + count((array)$items);
+      }
+    }
+
+    $x = ($documentCount - $documentsWithTerm + 0.5) / ($documentsWithTerm + 0.5);
+
+    return log(1 + abs($x));
+  }
+
+  private function createFieldVectors() {
+    $fieldVectors = [];
+    //$fieldRefs = array_keys($this->fieldTermFrequencies);
+
+    $termCache = [];
+    $score = 0;
+  //  var_dump($fieldRefs);
+  //  var_dump(array_values($this->fieldTermFrequencies));
+
+    //return;
+    foreach ($this->fieldTermFrequencies as $fieldRef => $terms) {
+      $fieldLength = $this->fieldLengths[$fieldRef];
+      $vector = [$fieldRef, []];
+      foreach ($terms as $term => $tf) {
+        $fieldName = explode("/", $fieldRef)[0];
+        $entry = $this->getTermInIndex($term, $this->invertedIndex);
+        $termIndex = $entry[1]->{"_index"};
+        if (!isset($termCache[$term])) {
+          $idf = $this->idf($entry, $this->documentCount);
+        }
+        else {
+          $idf = $termCache[$term];
+        }
+        $score = $idf * (($this->_k1 + 1) * $tf) / ($this->_k1 * (1 - $this->_b + $this->_b * ($fieldLength / $this->averageFieldLength[$fieldName])) + $tf);
+        // TODO: add boosts.
+        //$score *= fieldBoost
+        //score *= docBoost
+        $scoreWithPrecision = round($score * 1000) / 1000;
+        // Converts 1.23456789 to 1.234.
+        // Reducing the precision so that the vectors take up less
+        // space when serialised. Doing it now so that they behave
+        // the same before and after serialisation.
+        array_push($vector[1], $termIndex, $scoreWithPrecision);
+      }
+      $fieldVectors[] = $vector;
+
+    }
+    $this->fieldVectors = $fieldVectors;
+  }
+
+  public function output() {
+    $output = new stdClass;
+    $output->version = $this->version;
+    $output->fields = $this->fields;
+
+    usort($this->invertedIndex, ['BuildLunrIndex', 'sortInvertedIndex']);
+
+    $this->calculateAverageFieldLengths();
+    $this->createFieldVectors();
+
+    $output->fieldVectors = $this->fieldVectors;
+    $output->invertedIndex = $this->invertedIndex;
+    $output->pipeline = ["stemmer"];
+    return $output;
+  }
+}

--- a/modules/custom/interra_api/lunr.php/src/Pipeline.php
+++ b/modules/custom/interra_api/lunr.php/src/Pipeline.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @file
+ *
+ * Creates a simple pipeline to add functions to process tokens.
+ */
+
+
+/**
+ * Creates a simple pipeline to process tokens.
+ *
+ * Example:
+ *
+ * Create function to process tokens:
+ *
+ * function trimmer($token) {
+    return preg_replace("/[^A-Za-z0-9 ]/", '', $token);
+ * }
+ *
+ * $tokens = ["one", "two!", "three", '$five', "description"];
+ * $pipeline = new Pipeline();
+ * Add to the pipeline:
+ * $pipeline->add('trimmer');
+ * $results = $pipeline->run($tokens);
+ * var_dump($results);
+ *
+ * array(5) {
+ *  [0]=> string(3) "one"
+ *  [1]=> string(4) "two!"
+ *  [2]=> string(5) "three"
+ *  [3]=> string(4) "five"
+ *  [4]=> string(11) "description"
+ * }
+ *
+ */
+class Pipeline {
+
+  private $stack = [];
+
+  /**
+   * Adds functions to the pipeline.
+   *
+   * @param string $pipeline Function to add to the pipeline stack. Must be
+   * a function that accepts an argument for an array of tokens.
+   */
+  public function add(string $pipeline) {
+    $this->stack[] = $pipeline;
+  }
+
+  public function run(array $tokens) {
+    $pipelines = $this->stack;
+    foreach ($pipelines as $fn) {
+      $memo = [];
+      foreach ($tokens as $token) {
+        $result = $fn($token);
+        if ($result) {
+          $memo[] = $result;
+        }
+      }
+      $tokens = $memo;
+    }
+    return $tokens;
+  }
+}

--- a/modules/custom/interra_api/lunr.php/src/pipelines.php
+++ b/modules/custom/interra_api/lunr.php/src/pipelines.php
@@ -1,0 +1,174 @@
+<?php
+
+/**
+ * @file
+ *
+ * Pipeline functions for the index builder.
+ */
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use markfullmer\porter2\Porter2;
+
+/**
+ * Removes non-alphanumerica charactures from a string.
+ *
+ * @param string $token A string to be trimmed.
+ *
+ * @return string
+ *   Cleaned string.
+ */
+function trimmer(string $token) {
+  return preg_replace("/[^A-Za-z0-9 ]/", '', $token);
+}
+
+$stopWords = [
+  'a',
+  'able',
+  'about',
+  'across',
+  'after',
+  'all',
+  'almost',
+  'also',
+  'am',
+  'among',
+  'an',
+  'and',
+  'any',
+  'are',
+  'as',
+  'at',
+  'be',
+  'because',
+  'been',
+  'but',
+  'by',
+  'can',
+  'cannot',
+  'could',
+  'dear',
+  'did',
+  'do',
+  'does',
+  'either',
+  'else',
+  'ever',
+  'every',
+  'for',
+  'from',
+  'get',
+  'got',
+  'had',
+  'has',
+  'have',
+  'he',
+  'her',
+  'hers',
+  'him',
+  'his',
+  'how',
+  'however',
+  'i',
+  'if',
+  'in',
+  'into',
+  'is',
+  'it',
+  'its',
+  'just',
+  'least',
+  'let',
+  'like',
+  'likely',
+  'may',
+  'me',
+  'might',
+  'most',
+  'must',
+  'my',
+  'neither',
+  'no',
+  'nor',
+  'not',
+  'of',
+  'off',
+  'often',
+  'on',
+  'only',
+  'or',
+  'other',
+  'our',
+  'own',
+  'rather',
+  'said',
+  'say',
+  'says',
+  'she',
+  'should',
+  'since',
+  'so',
+  'some',
+  'than',
+  'that',
+  'the',
+  'their',
+  'them',
+  'then',
+  'there',
+  'these',
+  'they',
+  'this',
+  'tis',
+  'to',
+  'too',
+  'twas',
+  'us',
+  'wants',
+  'was',
+  'we',
+  'were',
+  'what',
+  'when',
+  'where',
+  'which',
+  'while',
+  'who',
+  'whom',
+  'why',
+  'will',
+  'with',
+  'would',
+  'yet',
+  'you',
+  'your'
+];
+
+/**
+ * Provides filtering mechanism for token strings by only return token if it
+ * does not exist in a list of stopwords.
+ *
+ * @param string $token Token to filter against.
+ * @return (string || bool)
+ *   Returns string it if not in the list, FALSE if it is.
+ */
+function stop_word_filter(string $token) {
+  global $stopWords;
+  if (!in_array($token, $stopWords)) {
+    return $token;
+  }
+  return FALSE;
+}
+
+/**
+ * Stems strings using Porter2 algorithm. Wrapper around
+ * https://github.com/markfullmer/porter2.
+ *
+ * @param string $token A string to be stemmed.
+ *
+ * @return string
+ *   Stemmed string.
+ */
+function stemmer(string $token) {
+  return Porter2::stem($token);
+}


### PR DESCRIPTION
This adds a library and integration to create a Lunr.js search backend in DKAN.

The ``lunr.php`` library could be used in any PHP application so may be moved elsewhere.

TODO:

* [ ] More docs
* [ ] Tests
* [ ] Replace ``search-index.json`` endpoint
* [ ] Update front-end and data-catalog-frontend