### PR TITLE
Improve docs endpoint, get api spec of unauthenticated routes

### DIFF
--- a/modules/custom/dkan_api/dkan_api.routing.yml
+++ b/modules/custom/dkan_api/dkan_api.routing.yml
@@ -1,10 +1,17 @@
 # Dynamic routes based on dkan_json_property_api's property_list config.
 route_callbacks:
   - '\Drupal\dkan_api\Routing\RouteProvider::routes'
-dkan_api.docs.get:
-  path: '/api/v1/docs'
+dkan_api.docs.get_spec_complete:
+  path: '/api/v1/docs/complete'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\dkan_api\Controller\Docs::getYmlSpec'}
+    { _controller: '\Drupal\dkan_api\Controller\Docs::getComplete'}
+  requirements:
+    _permission: 'access content'
+dkan_api.docs.get_spec_unauthenticated:
+  path: '/api/v1/docs/unauthenticated'
+  methods: [GET]
+  defaults:
+    { _controller: '\Drupal\dkan_api\Controller\Docs::getUnauthenticated'}
   requirements:
     _permission: 'access content'

--- a/modules/custom/dkan_api/src/Controller/Docs.php
+++ b/modules/custom/dkan_api/src/Controller/Docs.php
@@ -10,6 +10,13 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 class Docs implements ContainerInjectionInterface {
 
   /**
+   * The API array spec, to ease manipulation, before json encoding.
+   *
+   * @var array
+   */
+  protected $spec;
+
+  /**
    * Module handler.
    *
    * @var \Drupal\Core\Extension\ModuleHandlerInterface
@@ -22,6 +29,13 @@ class Docs implements ContainerInjectionInterface {
    * @var \Drupal\dkan_common\Service\Factory
    */
   protected $dkanFactory;
+
+  /**
+   * Serializer to translate yaml to json.
+   *
+   * @var Drupal\Component\Serialization\SerializationInterface
+   */
+  protected $ymlSerializer;
 
   /**
    * @{inheritdocs}
@@ -41,22 +55,85 @@ class Docs implements ContainerInjectionInterface {
     $this->container = $container;
     $this->moduleHandler = $container->get('module_handler');
     $this->dkanFactory = $container->get('dkan.factory');
+    $this->ymlSerializer = $container->get('serialization.yaml');
+
+    $this->spec = $this->getJsonFromYmlFile();
   }
 
   /**
-   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   * Load the yaml spec file and convert it to an array
+   *
+   * @return array
    */
-  public function getYmlSpec() {
+  protected function getJsonFromYmlFile() {
     $modulePath = $this->moduleHandler->getModule('dkan_api')->getPath();
     $ymlSpecPath = $modulePath . '/docs/dkan_api_openapi_spec.yml';
     $ymlSpec = file_get_contents($ymlSpecPath);
 
+    return $this->ymlSerializer->decode($ymlSpec);
+  }
+
+  /**
+   * Returns the complete API spec.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   */
+  public function getComplete() {
+    $jsonSpec = json_encode($this->spec);
+
     $response = $this->dkanFactory
       ->newJsonResponse();
-    $response->headers->set('Content-type', 'text/plain');
+    $response->headers->set('Content-type', 'application/json');
     $response->headers->set('Access-Control-Allow-Origin', '*');
-    $response->setContent($ymlSpec);
+    $response->setContent($jsonSpec);
 
     return $response;
   }
+
+  /**
+   * Returns only the publicly accessible GET requests for the API spec.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   */
+  public function getUnauthenticated() {
+    $specAnon =  $this->filterSpecOperations($this->spec, ['get']);
+    $jsonSpecAnon = json_encode($specAnon);
+
+    $response = $this->dkanFactory
+      ->newJsonResponse();
+    $response->headers->set('Content-type', 'application/json');
+    $response->headers->set('Access-Control-Allow-Origin', '*');
+    $response->setContent($jsonSpecAnon);
+
+    return $response;
+  }
+
+  /**
+   * Removes from the api spec's paths the operations not whitelisted.
+   *
+   * @param \stdClass $original
+   *   The original spec array.
+   * @param array $operations_allowed
+   *   Array of operations allowed.
+   *
+   * @return array
+   *   Modified spec, keeping only the specified operations.
+   */
+  protected function filterSpecOperations(array $original, array $operations_allowed) {
+    $spec = $original;
+
+    foreach ($spec['paths'] as $path => $operations) {
+      foreach ($operations as $verb => $details) {
+        if (!in_array($verb, $operations_allowed)) {
+          unset($spec['paths'][$path][$verb]);
+        }
+      }
+      if (empty($spec['paths'][$path])) {
+        unset($spec['paths'][$path]);
+      }
+    }
+
+    return $spec;
+  }
+
 }

--- a/modules/custom/dkan_api/src/Controller/Docs.php
+++ b/modules/custom/dkan_api/src/Controller/Docs.php
@@ -47,8 +47,6 @@ class Docs implements ContainerInjectionInterface {
 
   /**
    * Constructor.
-   *
-   * @codeCoverageIgnore
    */
   public function __construct(ContainerInterface $container) {
     $this->container = $container;
@@ -67,9 +65,22 @@ class Docs implements ContainerInjectionInterface {
   protected function getJsonFromYmlFile() {
     $modulePath = $this->moduleHandler->getModule('dkan_api')->getPath();
     $ymlSpecPath = $modulePath . '/docs/dkan_api_openapi_spec.yml';
-    $ymlSpec = file_get_contents($ymlSpecPath);
+    $ymlSpec = $this->fileGetContents($ymlSpecPath);
 
     return $this->ymlSerializer->decode($ymlSpec);
+  }
+
+  /**
+   * Wrapper around file_get_contents to facilitate testing.
+   *
+   * @param string $path
+   *
+   * @return false|string
+   *
+   * @codeCoverageIgnore
+   */
+  protected function fileGetContents($path) {
+    return file_get_contents($path);
   }
 
   /**
@@ -80,13 +91,7 @@ class Docs implements ContainerInjectionInterface {
   public function getComplete() {
     $jsonSpec = json_encode($this->spec);
 
-    $response = $this->dkanFactory
-      ->newJsonResponse();
-    $response->headers->set('Content-type', 'application/json');
-    $response->headers->set('Access-Control-Allow-Origin', '*');
-    $response->setContent($jsonSpec);
-
-    return $response;
+    return $this->sendResponse($jsonSpec);
   }
 
   /**
@@ -98,6 +103,17 @@ class Docs implements ContainerInjectionInterface {
     $specAnon =  $this->filterSpecOperations($this->spec, ['get']);
     $jsonSpecAnon = json_encode($specAnon);
 
+    return $this->sendResponse($jsonSpecAnon);
+  }
+
+  /**
+   * Helper function to set headers and send response.
+   *
+   * @param string $jsonSpecAnon
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   */
+  public function sendResponse(string $jsonSpecAnon) {
     $response = $this->dkanFactory
       ->newJsonResponse();
     $response->headers->set('Content-type', 'application/json');

--- a/modules/custom/dkan_api/src/Controller/Docs.php
+++ b/modules/custom/dkan_api/src/Controller/Docs.php
@@ -5,7 +5,6 @@ namespace Drupal\dkan_api\Controller;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\JsonResponse;
 
 class Docs implements ContainerInjectionInterface {
 
@@ -33,7 +32,7 @@ class Docs implements ContainerInjectionInterface {
   /**
    * Serializer to translate yaml to json.
    *
-   * @var Drupal\Component\Serialization\SerializationInterface
+   * @var \Symfony\Component\Serializer\Serializer
    */
   protected $ymlSerializer;
 

--- a/modules/custom/dkan_api/tests/src/Unit/Controller/DocsTest.php
+++ b/modules/custom/dkan_api/tests/src/Unit/Controller/DocsTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Drupal\Tests\dkan_api\Unit\Controller;
+
+use Drupal\dkan_api\Controller\Docs;
+use Drupal\dkan_common\Tests\DkanTestBase;
+use Drupal\dkan_common\Service\Factory;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class DocsTest extends DkanTestBase {
+
+  public function testConstruct() {
+    // Setup.
+    $mock = $this->getMockBuilder(Docs::class)
+      ->disableOriginalConstructor()
+      ->setMethods([
+        'getJsonFromYmlFile',
+      ])
+      ->getMock();
+
+    $mockContainer = $this->getMockContainer();
+
+    $mockDkanFactory = $this->createMock(Factory::class);
+    $mockModuleHandler = $this->createMock(ModuleHandlerInterface::class);
+    $mockYmlSerializer = $this->createMock(SerializerInterface::class);
+
+    // Expect.
+    $mockContainer->expects($this->exactly(3))
+      ->method('get')
+      ->withConsecutive(
+        ['module_handler'],
+        ['dkan.factory'],
+        ['serialization.yaml']
+      )
+      ->willReturnOnConsecutiveCalls(
+        $mockModuleHandler,
+        $mockDkanFactory,
+        $mockYmlSerializer
+      );
+    $mock->expects($this->once())
+      ->method('getJsonFromYmlFile')
+      ->with()
+      ->willReturn([]);
+
+    // Assert.
+    $mock->__construct($mockContainer);
+    $this->assertSame(
+      $mockContainer,
+      $this->readAttribute($mock, 'container')
+    );
+    $this->assertSame(
+      $mockModuleHandler,
+      $this->readAttribute($mock, 'moduleHandler')
+    );
+    $this->assertSame(
+      $mockDkanFactory,
+      $this->readAttribute($mock, 'dkanFactory')
+    );
+    $this->assertSame(
+      $mockYmlSerializer,
+      $this->readAttribute($mock, 'ymlSerializer')
+    );
+  }
+
+  public function testGetComplete() {
+    // Setup.
+    $mock = $this->getMockBuilder(Docs::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['sendResponse'])
+      ->getMock();
+
+    $test = (object) [
+      "openapi" => "3.0.1",
+      "info" => [
+        "title" => "Test API",
+      ]
+    ];
+    $this->writeProtectedProperty($mock, 'spec', $test);
+
+    $mockJsonResponse = $this->createMock(JsonResponse::class);
+
+    // Expect.
+    $mock->expects($this->once())
+      ->method('sendResponse')
+      ->with(json_encode($test))
+      ->willReturn($mockJsonResponse);
+
+    // Assert.
+    $actual = $this->invokeProtectedMethod($mock, 'getComplete');
+    $this->assertEquals($mockJsonResponse, $actual);
+  }
+
+  public function testGetUnauthenticated() {
+    // Setup.
+    $mock = $this->getMockBuilder(Docs::class)
+      ->disableOriginalConstructor()
+      ->setMethods([
+        'filterSpecOperations',
+        'sendResponse',
+      ])
+      ->getMock();
+
+    $test = [];
+    $filtered_array = [];
+    $this->writeProtectedProperty($mock, 'spec', $test);
+
+    $mockJsonResponse = $this->createMock(JsonResponse::class);
+
+    // Expect.
+    $mock->expects($this->once())
+      ->method('filterSpecOperations')
+      ->with($test, ['get'])
+      ->willReturn($filtered_array);
+    $mock->expects($this->once())
+      ->method('sendResponse')
+      ->with(json_encode($filtered_array))
+      ->willReturn($mockJsonResponse);
+
+    // Assert.
+    $actual = $this->invokeProtectedMethod($mock, 'getUnauthenticated');
+    $this->assertEquals($mockJsonResponse, $actual);
+  }
+
+  /**
+   * Provides data to test filterSpecOperations.
+   */
+  public function dataTestFilterSpecOperations() {
+    return [
+      'Filtering by bar removes foo and resulting empty path' => [
+        [ 'paths' => [
+            'pathWithOnlyFoo' => [
+              'foo' => 'one',
+            ],
+            'pathWithBothFooAndBar' => [
+              'bar' => 'two',
+              'foo' => 'three',
+            ],
+          ]
+        ],
+        ['bar'],
+        ['paths' => [
+            'pathWithBothFooAndBar' => [
+              'bar' => 'two',
+            ],
+          ]
+        ]
+      ],
+    ];
+  }
+
+  /**
+   * @param $original
+   * @param $operations_allowed
+   * @param $expected
+   *
+   * @dataProvider dataTestFilterSpecOperations
+   */
+  public function testFilterSpecOperations($original, $operations_allowed, $expected) {
+    // Setup.
+    $mock = $this->getMockBuilder(Docs::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    // Assert.
+    $actual = $this->invokeProtectedMethod($mock, 'filterSpecOperations', $original, $operations_allowed);
+    $this->assertEquals($expected, $actual);
+  }
+
+}


### PR DESCRIPTION
* Converts the returned openapi spec to json
* Adds route `api/v1/docs/unauthenticated` to api docs endpoint