### PR TITLE
Dataset specific api spec

### DIFF
--- a/modules/custom/dkan_api/dkan_api.routing.yml
+++ b/modules/custom/dkan_api/dkan_api.routing.yml
@@ -2,16 +2,16 @@
 route_callbacks:
   - '\Drupal\dkan_api\Routing\RouteProvider::routes'
 dkan_api.docs.get_spec_complete:
-  path: '/api/v1/docs/complete'
+  path: '/api/v1/docs'
   methods: [GET]
   defaults:
     { _controller: '\Drupal\dkan_api\Controller\Docs::getComplete'}
   requirements:
     _permission: 'access content'
 dkan_api.docs.get_spec_unauthenticated:
-  path: '/api/v1/docs/unauthenticated'
+  path: '/api/v1/docs/{uuid}'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\dkan_api\Controller\Docs::getUnauthenticated'}
+    { _controller: '\Drupal\dkan_api\Controller\Docs::getDatasetSpecific'}
   requirements:
     _permission: 'access content'

--- a/modules/custom/dkan_api/docs/dkan_api_openapi_spec.yml
+++ b/modules/custom/dkan_api/docs/dkan_api_openapi_spec.yml
@@ -1,13 +1,13 @@
 openapi: 3.0.1
 info:
-  title: DKAN API Documentation
+  title: API Documentation
   version: Alpha
     # description: Description goes here.
     # license:
     # name: Apache 2.0
   # url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 tags:
-  - name: Datasets
+  - name: Dataset
       # description:
       # externalDocs:
       # description:
@@ -33,7 +33,7 @@ paths:
       summary: Get all datasets
       # description:
       tags:
-        - Datasets
+        - Dataset
       responses:
         200:
           description: Ok
@@ -41,7 +41,7 @@ paths:
       summary: Create a dataset
       # description:
       tags:
-        - Datasets
+        - Dataset
       security:
         - basicAuth: []
       responses:
@@ -53,10 +53,10 @@ paths:
           description: Something went wrong
   /api/v1/dataset/{uuid}:
     get:
-      summary: Get a dataset
+      summary: Get this dataset
       # description:
       tags:
-        - Datasets
+        - Dataset
       parameters:
         - name: "uuid"
           in: "path"
@@ -73,7 +73,7 @@ paths:
       summary: Replace a dataset
       # description:
       tags:
-        - Datasets
+        - Dataset
       security:
         - basicAuth: []
       parameters:
@@ -96,7 +96,7 @@ paths:
       summary: Update a dataset
       # description:
       tags:
-        - Datasets
+        - Dataset
       security:
         - basicAuth: []
       parameters:
@@ -119,7 +119,7 @@ paths:
       summary: Delete a dataset
       # description:
       tags:
-        - Datasets
+        - Dataset
       security:
         - basicAuth: []
       parameters:

--- a/modules/custom/dkan_api/src/Controller/Docs.php
+++ b/modules/custom/dkan_api/src/Controller/Docs.php
@@ -127,6 +127,9 @@ class Docs implements ContainerInjectionInterface {
     ]);
     // Remove the security schemes.
     unset($spec['components']);
+    // Remove required parameters, since now part of path.
+    unset($spec['paths']['/api/v1/sql/{query}']['get']['parameters']);
+    unset($spec['paths']['/api/v1/dataset/{uuid}']['get']['parameters']);
     // Keep only the tags needed, so remove the properties tag.
     $spec['tags'] = [
       ["name" => "Dataset"],

--- a/modules/custom/dkan_api/src/Controller/Docs.php
+++ b/modules/custom/dkan_api/src/Controller/Docs.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types=1);
+
+declare(strict_types = 1);
 
 namespace Drupal\dkan_api\Controller;
 
@@ -7,6 +8,9 @@ use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\dkan_data\ValueReferencer;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+/**
+ * Serves openapi spec for dataset-related endpoints.
+ */
 class Docs implements ContainerInjectionInterface {
 
   /**
@@ -68,9 +72,10 @@ class Docs implements ContainerInjectionInterface {
   }
 
   /**
-   * Load the yaml spec file and convert it to an array
+   * Load the yaml spec file and convert it to an array.
    *
    * @return array
+   *   The openapi spec.
    */
   protected function getJsonFromYmlFile() {
     $modulePath = $this->moduleHandler->getModule('dkan_api')->getPath();
@@ -84,8 +89,10 @@ class Docs implements ContainerInjectionInterface {
    * Wrapper around file_get_contents to facilitate testing.
    *
    * @param string $path
+   *   Path for our yml spec.
    *
    * @return false|string
+   *   Our yml file, or FALSE.
    *
    * @codeCoverageIgnore
    */
@@ -97,6 +104,7 @@ class Docs implements ContainerInjectionInterface {
    * Returns the complete API spec.
    *
    * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   OpenAPI spec response.
    */
   public function getComplete() {
     $jsonSpec = json_encode($this->spec);
@@ -108,12 +116,14 @@ class Docs implements ContainerInjectionInterface {
    * Returns only dataset-specific GET requests for the API spec.
    *
    * @param \Drupal\dkan_api\Controller\string $uuid
+   *   Dataset uuid.
    *
    * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   OpenAPI spec response.
    */
   public function getDatasetSpecific(string $uuid) {
     // Keep only the GET requests.
-    $spec =  $this->removeSpecOperations($this->spec, [
+    $spec = $this->removeSpecOperations($this->spec, [
       'post',
       'put',
       'patch',
@@ -148,18 +158,23 @@ class Docs implements ContainerInjectionInterface {
   /**
    * Helper function to set headers and send response.
    *
-   * @param string $jsonSpecAnon
+   * @param string $jsonSpec
+   *   OpenAPI spec encoded json response.
    *
    * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   OpenAPI spec response.
    */
-  public function sendResponse(string $jsonSpecAnon) {
-    $response = $this->dkanFactory
-      ->newJsonResponse();
-    $response->headers->set('Content-type', 'application/json');
-    $response->headers->set('Access-Control-Allow-Origin', '*');
-    $response->setContent($jsonSpecAnon);
-
-    return $response;
+  public function sendResponse(string $jsonSpec) {
+    return $this->dkanFactory
+      ->newJsonResponse(
+        $jsonSpec,
+        200,
+        [
+          'Content-type' => 'application/json',
+          'Access-Control-Allow-Origin' => '*',
+        ],
+        TRUE
+      );
   }
 
   /**

--- a/modules/custom/dkan_api/tests/src/Unit/Controller/DocsTest.php
+++ b/modules/custom/dkan_api/tests/src/Unit/Controller/DocsTest.php
@@ -143,6 +143,40 @@ class DocsTest extends DkanTestBase {
     $this->assertEquals($mockJsonResponse, $actual);
   }
 
+  public function testSendResponse() {
+    // Setup
+    $mock = $this->getMockBuilder(Docs::class)
+      ->disableOriginalConstructor()
+      ->getMockForAbstractClass();
+
+    $mockDkanFactory = $this->getMockBuilder(Factory::class)
+      ->setMethods(['newJsonResponse'])
+      ->disableOriginalConstructor()
+      ->getMock();
+    $this->writeProtectedProperty($mock, 'dkanFactory', $mockDkanFactory);
+
+    $mockJsonResponse = $this->createMock(JsonResponse::class);
+
+    $data = '{}';
+
+    // Expect
+    $mockDkanFactory->expects($this->once())
+      ->method('newJsonResponse')
+      ->with(
+        $data,
+        200,
+        [
+          'Content-type' => 'application/json',
+          'Access-Control-Allow-Origin' => '*',
+        ]
+      )
+      ->willReturn($mockJsonResponse);
+
+    // Asset
+    $actual = $mock->sendResponse($data);
+    $this->assertSame($mockJsonResponse, $actual);
+  }
+
   /**
    * Provides data to test removeSpecOperations.
    */

--- a/modules/custom/dkan_api/tests/src/Unit/Controller/DocsTest.php
+++ b/modules/custom/dkan_api/tests/src/Unit/Controller/DocsTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\dkan_api\Unit\Controller;
 
 use Drupal\dkan_api\Controller\Docs;
+use Drupal\dkan_api\Storage\DrupalNodeDataset;
 use Drupal\dkan_common\Tests\DkanTestBase;
 use Drupal\dkan_common\Service\Factory;
 use Drupal\Core\Extension\ModuleHandlerInterface;
@@ -25,19 +26,27 @@ class DocsTest extends DkanTestBase {
     $mockDkanFactory = $this->createMock(Factory::class);
     $mockModuleHandler = $this->createMock(ModuleHandlerInterface::class);
     $mockYmlSerializer = $this->createMock(SerializerInterface::class);
+    $mockStorage = $this->getMockBuilder(DrupalNodeDataset::class)
+      ->disableOriginalConstructor()
+      ->setMethods([
+        'setSchema',
+      ])
+      ->getMock();
 
     // Expect.
-    $mockContainer->expects($this->exactly(3))
+    $mockContainer->expects($this->exactly(4))
       ->method('get')
       ->withConsecutive(
         ['module_handler'],
         ['dkan.factory'],
-        ['serialization.yaml']
+        ['serialization.yaml'],
+        ['dkan_api.storage.drupal_node_dataset']
       )
       ->willReturnOnConsecutiveCalls(
         $mockModuleHandler,
         $mockDkanFactory,
-        $mockYmlSerializer
+        $mockYmlSerializer,
+        $mockStorage
       );
     $mock->expects($this->once())
       ->method('getJsonFromYmlFile')
@@ -46,10 +55,6 @@ class DocsTest extends DkanTestBase {
 
     // Assert.
     $mock->__construct($mockContainer);
-    $this->assertSame(
-      $mockContainer,
-      $this->readAttribute($mock, 'container')
-    );
     $this->assertSame(
       $mockModuleHandler,
       $this->readAttribute($mock, 'moduleHandler')
@@ -62,6 +67,11 @@ class DocsTest extends DkanTestBase {
       $mockYmlSerializer,
       $this->readAttribute($mock, 'ymlSerializer')
     );
+    $this->assertSame(
+      $mockStorage,
+      $this->readAttribute($mock, 'storage')
+    );
+
   }
 
   public function testGetComplete() {
@@ -92,44 +102,54 @@ class DocsTest extends DkanTestBase {
     $this->assertEquals($mockJsonResponse, $actual);
   }
 
-  public function testGetUnauthenticated() {
+  public function testGetDatasetSpecific() {
     // Setup.
     $mock = $this->getMockBuilder(Docs::class)
       ->disableOriginalConstructor()
       ->setMethods([
-        'filterSpecOperations',
+        'removeSpecOperations',
+        'removeSpecPaths',
+        'replaceDistributions',
         'sendResponse',
       ])
       ->getMock();
 
-    $test = [];
-    $filtered_array = [];
-    $this->writeProtectedProperty($mock, 'spec', $test);
+    $someUuid = uniqid('uuid_');
+
+    $this->writeProtectedProperty($mock, 'spec', []);
 
     $mockJsonResponse = $this->createMock(JsonResponse::class);
 
     // Expect.
     $mock->expects($this->once())
-      ->method('filterSpecOperations')
-      ->with($test, ['get'])
-      ->willReturn($filtered_array);
+      ->method('removeSpecOperations')
+      ->withAnyParameters()
+      ->willReturn([]);
+    $mock->expects($this->once())
+      ->method('removeSpecPaths')
+      ->withAnyParameters()
+      ->willReturn(['paths' => ['/api/v1/dataset/{uuid}' => []]]);
+    $mock->expects($this->once())
+      ->method('replaceDistributions')
+      ->withAnyParameters()
+      ->willReturn([]);
     $mock->expects($this->once())
       ->method('sendResponse')
-      ->with(json_encode($filtered_array))
+      ->with(json_encode([]))
       ->willReturn($mockJsonResponse);
 
     // Assert.
-    $actual = $this->invokeProtectedMethod($mock, 'getUnauthenticated');
+    $actual = $this->invokeProtectedMethod($mock, 'getDatasetSpecific', $someUuid);
     $this->assertEquals($mockJsonResponse, $actual);
   }
 
   /**
-   * Provides data to test filterSpecOperations.
+   * Provides data to test removeSpecOperations.
    */
-  public function dataTestFilterSpecOperations() {
+  public function dataTestRemoveSpecOperations() {
     return [
-      'Filtering by bar removes foo and resulting empty path' => [
-        [ 'paths' => [
+      'Removing `foo` resulting empty path' => [
+        ['paths' => [
             'pathWithOnlyFoo' => [
               'foo' => 'one',
             ],
@@ -139,7 +159,7 @@ class DocsTest extends DkanTestBase {
             ],
           ]
         ],
-        ['bar'],
+        ['foo'],
         ['paths' => [
             'pathWithBothFooAndBar' => [
               'bar' => 'two',
@@ -152,19 +172,37 @@ class DocsTest extends DkanTestBase {
 
   /**
    * @param $original
-   * @param $operations_allowed
+   * @param $ops_to_remove
    * @param $expected
    *
-   * @dataProvider dataTestFilterSpecOperations
+   * @dataProvider dataTestRemoveSpecOperations
    */
-  public function testFilterSpecOperations($original, $operations_allowed, $expected) {
+  public function testRemoveSpecOperations($original, $ops_to_remove, $expected) {
     // Setup.
     $mock = $this->getMockBuilder(Docs::class)
       ->disableOriginalConstructor()
       ->getMock();
 
     // Assert.
-    $actual = $this->invokeProtectedMethod($mock, 'filterSpecOperations', $original, $operations_allowed);
+    $actual = $this->invokeProtectedMethod($mock, 'removeSpecOperations', $original, $ops_to_remove);
+    $this->assertEquals($expected, $actual);
+  }
+
+  public function testRemoveSpecPaths() {
+    // Setup.
+    $mock = $this->getMockBuilder(Docs::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+    $test = ['paths' => [
+      'keep' => [],
+      'remove' => [],
+    ]];
+    $expected = ['paths' => [
+      'keep' => [],
+    ]];
+
+    // Assert.
+    $actual = $this->invokeProtectedMethod($mock, 'removeSpecPaths', $test, ['remove']);
     $this->assertEquals($expected, $actual);
   }
 


### PR DESCRIPTION
Modifies the openapi dkan spec for a specific dataset uuid.

Steps to tests:
1. Check out branch, clear cache
2. Use curl or Postman to `GET` `dkan/api/v1/docs/specific/c9e2d352-e24c-4051-9158-f48127aa5692`
3. Paste the resulting json into [Swagger Editor](https://editor.swagger.io/) (it will ask you to convert json to yaml, do it)
4. Verify the resulting API Docs is specific to this dataset, with two paths: one to get this dataset and one to get a sample result of resource's sql query: ```"paths": {
    "/api/v1/dataset/c9e2d352-e24c-4051-9158-f48127aa5692": { ... },
    "/api/v1/sql/[SELECT * FROM 36c5bdc2-d60b-410f-8666-07354516ee10];": { ... }
}```
5. If possible, try with other dataset which have resources in the datastore