### PR TITLE
Apply coding standards and fix some typos

### DIFF
--- a/modules/custom/dkan_harvest/src/Drush/Commands.php
+++ b/modules/custom/dkan_harvest/src/Drush/Commands.php
@@ -22,10 +22,10 @@ class Commands extends DrushCommands {
      * @var HarvestFactory
      */
     protected $harvestFactory;
-    
+
     /**
      *
-     * @var HarvestService 
+     * @var HarvestService
      */
     protected $harvestService;
     /**
@@ -42,7 +42,7 @@ class Commands extends DrushCommands {
     }
 
   /**
-   * Lists avaialble harvests.
+   * Lists available harvests.
    *
    * @command dkan-harvest:list
    *
@@ -70,7 +70,7 @@ class Commands extends DrushCommands {
             $plan       = json_decode($harvest_plan);
             $identifier = $this->harvestService
                     ->registerHarvest($plan);
-            $this->logger->notice("Succesfully registered the {$identifier} harvest.");
+            $this->logger->notice("Successfully registered the {$identifier} harvest.");
         } catch (\Exception $e) {
             $this->logger->error($e->getMessage());
             $this->logger->debug($e->getTraceAsString());
@@ -86,7 +86,7 @@ class Commands extends DrushCommands {
     try {
       if($this->harvestService->deregisterHarvest($id))
       {
-        $message = "Succesfully deregistered the {$id} harvest.";
+        $message = "Successfully deregistered the {$id} harvest.";
       }
     }
     catch(\Exception $e) {
@@ -182,5 +182,5 @@ class Commands extends DrushCommands {
     (new ConsoleOutput())->write("{$result} items reverted for the '{$id}' harvest plan." . PHP_EOL);
   }
 
- 
+
 }

--- a/modules/custom/dkan_harvest/src/Drush/Commands.php
+++ b/modules/custom/dkan_harvest/src/Drush/Commands.php
@@ -2,44 +2,43 @@
 
 namespace Drupal\dkan_harvest\Drush;
 
-use Harvest\ETL\Factory;
-use Harvest\ResultInterpreter;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
 use Drush\Commands\DrushCommands;
-use \Drupal\dkan_harvest\Service\Factory as HarvestFactory;
-use Drupal\dkan_harvest\Service\Harvest as HarvestService;
-use Drupal\Core\Logger\LoggerChannelInterface;
 
 /**
  * @codeCoverageIgnore
  */
 class Commands extends DrushCommands {
 
-    /**
-     *
-     * @var HarvestFactory
-     */
-    protected $harvestFactory;
+  /**
+   *
+   * @var \Drupal\dkan_harvest\Service\Factory
+   */
+  protected $harvestFactory;
 
-    /**
-     *
-     * @var HarvestService
-     */
-    protected $harvestService;
-    /**
-     *
-     * @var LoggerChannelInterface
-     */
-    protected $logger;
+  /**
+   *
+   * @var \Drupal\dkan_harvest\Service\Harvest
+   */
+  protected $harvestService;
 
-    public function __construct() {
-        //@todo passing via arguments doesn't seem play well with drush.services.yml
-        $this->harvestFactory = \Drupal::service('dkan_harvest.factory');
-        $this->harvestService = \Drupal::service('dkan_harvest.service');
-        $this->logger = \Drupal::service('dkan_harvest.logger_channel');
-    }
+  /**
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected $logger;
+
+  /**
+   * Commands constructor.
+   */
+  public function __construct() {
+    // @todo passing via arguments doesn't seem play well with drush.services.yml
+    $this->harvestFactory = \Drupal::service('dkan_harvest.factory');
+    $this->harvestService = \Drupal::service('dkan_harvest.service');
+    $this->logger = \Drupal::service('dkan_harvest.logger_channel');
+  }
 
   /**
    * Lists available harvests.
@@ -50,46 +49,46 @@ class Commands extends DrushCommands {
    *   List available harvests.
    */
   public function index() {
-    // each row needs to be an array for display.
+    // Each row needs to be an array for display.
     $rows = array_map(
-      function($id) {
-      return [$id];
-    },
+      function ($id) {
+        return [$id];
+      },
       $this->harvestService->getAllHarvestIds()
       );
     (new Table(new ConsoleOutput()))->setHeaders(['plan id'])->setRows($rows)->render();
   }
 
-    /**
-     * Register a new harvest.
-     *
-     * @command dkan-harvest:register
-     */
-    public function register($harvest_plan) {
-        try {
-            $plan       = json_decode($harvest_plan);
-            $identifier = $this->harvestService
-                    ->registerHarvest($plan);
-            $this->logger->notice("Successfully registered the {$identifier} harvest.");
-        } catch (\Exception $e) {
-            $this->logger->error($e->getMessage());
-            $this->logger->debug($e->getTraceAsString());
-        }
+  /**
+   * Register a new harvest.
+   *
+   * @command dkan-harvest:register
+   */
+  public function register($harvest_plan) {
+    try {
+      $plan       = json_decode($harvest_plan);
+      $identifier = $this->harvestService
+        ->registerHarvest($plan);
+      $this->logger->notice("Successfully registered the {$identifier} harvest.");
     }
+    catch (\Exception $e) {
+      $this->logger->error($e->getMessage());
+      $this->logger->debug($e->getTraceAsString());
+    }
+  }
 
-    /**
-     * Deregister a harvest.
-     *
-     * @command dkan-harvest:deregister
-     */
+  /**
+   * Deregister a harvest.
+   *
+   * @command dkan-harvest:deregister
+   */
   public function deregister($id) {
     try {
-      if($this->harvestService->deregisterHarvest($id))
-      {
+      if ($this->harvestService->deregisterHarvest($id)) {
         $message = "Successfully deregistered the {$id} harvest.";
       }
     }
-    catch(\Exception $e) {
+    catch (\Exception $e) {
       $message = $e->getMessage();
     }
 
@@ -109,7 +108,7 @@ class Commands extends DrushCommands {
    */
   public function run($id) {
     $result = $this->harvestService
-            ->runHarvest($id);
+      ->runHarvest($id);
 
     $this->renderResult($result);
   }
@@ -125,10 +124,10 @@ class Commands extends DrushCommands {
   public function runAll() {
 
     $ids = $this->harvestService
-            ->getAllHarvestIds();;
+      ->getAllHarvestIds();;
 
-    foreach($ids as $id){
-        $this->run($id);
+    foreach ($ids as $id) {
+      $this->run($id);
     }
   }
 
@@ -138,15 +137,15 @@ class Commands extends DrushCommands {
    * @param string $id
    *   The harvest id.
    * @param string $run_id
-   *   The run's id
+   *   The run's id.
    *
    * @command dkan-harvest:info
    */
-  public function info($id, $run_id = null) {
+  public function info($id, $run_id = NULL) {
 
     if (!isset($run_id)) {
       $runs = $this->harvestService
-              ->getAllHarvestRunInfo($id);
+        ->getAllHarvestRunInfo($id);
       $table = new Table(new ConsoleOutput());
       $table->setHeaders(["{$id} runs"]);
       foreach (array_keys($runs) as $run_id) {
@@ -156,7 +155,7 @@ class Commands extends DrushCommands {
     }
     else {
       $run = $this->harvestService
-              ->getHarvestRunInfo($id, $run_id);
+        ->getHarvestRunInfo($id, $run_id);
       $result = json_decode($run);
       print_r($result);
     }
@@ -177,10 +176,9 @@ class Commands extends DrushCommands {
   public function revert($id) {
 
     $result = $this->harvestService
-            ->revertHarvest($id);
+      ->revertHarvest($id);
 
     (new ConsoleOutput())->write("{$result} items reverted for the '{$id}' harvest plan." . PHP_EOL);
   }
-
 
 }


### PR DESCRIPTION
Had a local branch including some corrections / clean-up when I was working on 453. This was stuck in no-builds-land until the recent build fixes.

No new code, just fixed 3 types and applied Drupal coding standards by running the code beautifier and fixer at command line.