### PR TITLE
Add Dredd tests to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
             cd ~/sandbox
             dktl install
       - run:
-          name: Run cypress tests
+          name: Run integration tests (cypress, dredd)
           command: |
             export PATH=$PATH:~/dkan-tools/bin
             cd ~/sandbox
@@ -72,6 +72,7 @@ jobs:
             dktl drush dkan-datastore:import c9e2d352-e24c-4051-9158-f48127aa5692
             dktl drush dkan-datastore:import 5dc1cfcf-8028-476c-a020-f58ec6dd621c
             dktl dkan:test-cypress
+            dktl dkan:test-dredd
       - store_artifacts:
           path: ~/sandbox/docroot/profiles/contrib/dkan2/cypress/screenshots
       - store_test_results:


### PR DESCRIPTION
CircleCI fails for the same reason it does on master: Two unit tests fail.

I created a `test` branch to test CircleCI with the skipping of the two above tests, to proceed beyond them and test the Circle changes: The result for that test is here: https://circleci.com/gh/GetDKAN/dkan2/742

Expand the integration part of the result, and one can verify that Dredd is passing.

This PR also adds Dredd to CircleCI but without skipping the 2 unit tests.
For that reason I believe it is safe to merge.
Feel free to reach out if you have any questions or concerns. 