### PR TITLE
Remove openapi and dredd endpoints to create or delete property references

### DIFF
--- a/dredd/dredd-hooks.js
+++ b/dredd/dredd-hooks.js
@@ -9,11 +9,9 @@ const hooks = require('hooks');
  * or we can create some as needed.
  */
 endpointsToSkip = [
-  '/api/v1/{property} > Create a property > 201 > application/json',
   '/api/v1/{property}/{uuid} > Get a property > 200 > application/json',
   '/api/v1/{property}/{uuid} > Replace a property > 200 > application/json',
   '/api/v1/{property}/{uuid} > Update a property > 200 > application/json',
-  '/api/v1/{property}/{uuid} > Delete a property > 200 > application/json',
   '/api/v1/sql/{query} > Query resources in datastore > 200 > application/json',
   '/api/v1/harvest > Register a new harvest > 200 > application/json',
   '/api/v1/harvest/info/{id} > List previous runs for a harvest id > 200 > application/json',
@@ -42,10 +40,8 @@ endpointsRequiringAuth = [
   '/api/v1/dataset/{uuid} > Replace a dataset > 200 > application/json',
   '/api/v1/dataset/{uuid} > Update a dataset > 200 > application/json',
   '/api/v1/dataset/{uuid} > Delete a dataset > 200 > application/json',
-  '/api/v1/{property} > Create a property > 201 > application/json',
   '/api/v1/{property}/{uuid} > Replace a property > 200 > application/json',
   '/api/v1/{property}/{uuid} > Update a property > 200 > application/json',
-  '/api/v1/{property}/{uuid} > Delete a property > 200 > application/json',
   '/api/v1/harvest > Register a new harvest > 200 > application/json',
   '/api/v1/harvest/run/{id} > Runs a harvest > 200 > application/json',
   '/api/v1/datastore/{uuid} > Drop a datastore > 200 > application/json',

--- a/modules/custom/dkan_api/docs/dkan_api_openapi_spec.yml
+++ b/modules/custom/dkan_api/docs/dkan_api_openapi_spec.yml
@@ -290,43 +290,6 @@ paths:
                   properties:
                     identifier:
                       type: string
-    post:
-      operationId: property-create
-      summary: Create a property
-      tags:
-        - Properties
-      security:
-        - basicAuth: []
-      parameters:
-        - $ref: '#/components/parameters/property'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - identifier
-              properties:
-                identifier:
-                  type: string
-      responses:
-        '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                  - endpoint
-                  - identifier
-                properties:
-                  endpoint:
-                    type: string
-                  identifier:
-                    type: string
-        '401':
-          description: Unauthorized
   /api/v1/{property}/{uuid}:
     get:
       operationId: property-get
@@ -417,30 +380,6 @@ paths:
                   endpoint:
                     type: string
                   identifier:
-                    type: string
-        '401':
-          description: Unauthorized
-    delete:
-      operationId: property-delete
-      summary: Delete a property
-      tags:
-        - Properties
-      security:
-        - basicAuth: []
-      parameters:
-        - $ref: '#/components/parameters/property'
-        - $ref: '#/components/parameters/propertyUuid'
-      responses:
-        '200':
-          description: Property has been deleted
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                  - message
-                properties:
-                  message:
                     type: string
         '401':
           description: Unauthorized

--- a/modules/custom/dkan_api/src/Routing/RouteProvider.php
+++ b/modules/custom/dkan_api/src/Routing/RouteProvider.php
@@ -52,18 +52,21 @@ class RouteProvider {
       // GET individual.
       $get = $this->routeHelper($schema, "/api/v1/$schema/{uuid}", 'GET', 'get');
       $public_routes->add("dkan_api.{$schema}.get", $get);
-      // POST.
-      $post = $this->routeHelper($schema, "/api/v1/$schema", 'POST', 'post');
-      $authenticated_routes->add("dkan_api.{$schema}.post", $post);
       // PUT.
       $put = $this->routeHelper($schema, "/api/v1/$schema/{uuid}", 'PUT', 'put');
       $authenticated_routes->add("dkan_api.{$schema}.put", $put);
       // PATCH.
       $patch = $this->routeHelper($schema, "/api/v1/$schema/{uuid}", 'PATCH', 'patch');
       $authenticated_routes->add("dkan_api.{$schema}.patch", $patch);
-      // DELETE.
-      $delete = $this->routeHelper($schema, "/api/v1/$schema/{uuid}", 'DELETE', 'delete');
-      $authenticated_routes->add("dkan_api.{$schema}.delete", $delete);
+      // Only applicable to datasets.
+      if ($schema === 'dataset') {
+        // POST.
+        $post = $this->routeHelper($schema, "/api/v1/$schema", 'POST', 'post');
+        $authenticated_routes->add("dkan_api.{$schema}.post", $post);
+        // DELETE.
+        $delete = $this->routeHelper($schema, "/api/v1/$schema/{uuid}", 'DELETE', 'delete');
+        $authenticated_routes->add("dkan_api.{$schema}.delete", $delete);
+      }
     }
 
     $public_routes->addRequirements(['_access' => 'TRUE']);

--- a/modules/custom/dkan_api/src/Routing/RouteProvider.php
+++ b/modules/custom/dkan_api/src/Routing/RouteProvider.php
@@ -69,13 +69,28 @@ class RouteProvider {
       }
     }
 
-    $public_routes->addRequirements(['_access' => 'TRUE']);
-    $authenticated_routes->addRequirements(['_permission' => 'post put delete datasets through the api']);
-    $authenticated_routes->addOptions(['_auth' => ['basic_auth']]);
+    $this->setPublicRoutesAccess($public_routes);
+    $this->setPrivateRoutesAccess($authenticated_routes);
+
     $routes->addCollection($public_routes);
     $routes->addCollection($authenticated_routes);
 
     return $routes;
+  }
+
+  /**
+   * Private.
+   */
+  private function setPublicRoutesAccess($routes) {
+    $routes->addRequirements(['_access' => 'TRUE']);
+  }
+
+  /**
+   * Private.
+   */
+  private function setPrivateRoutesAccess($routes) {
+    $routes->addRequirements(['_permission' => 'post put delete datasets through the api']);
+    $routes->addOptions(['_auth' => ['basic_auth']]);
   }
 
   /**


### PR DESCRIPTION
Per discussion with @fmizzell, creating or deleting property references does not make sense, as they should created or deleted as a side effect of datasets being modified, not directly.

This removes their documentation and dredd tests.