### PR TITLE
Limit number of rows returned from sql endpoint

### DIFF
--- a/modules/custom/dkan_datastore/src/Storage/DatabaseTable.php
+++ b/modules/custom/dkan_datastore/src/Storage/DatabaseTable.php
@@ -162,7 +162,7 @@ class DatabaseTable implements StorageInterface, \JsonSerializable {
         $db_query->range($query->offset, $query->limit);
       }
       else {
-        $db_query->range(1, $query->limit);
+        $db_query->range(0, $query->limit);
       }
     }
     elseif ($query->offset) {

--- a/modules/custom/dkan_sql_endpoint/config/install/dkan_sql_endpoint.settings.yml
+++ b/modules/custom/dkan_sql_endpoint/config/install/dkan_sql_endpoint.settings.yml
@@ -1,0 +1,1 @@
+rows_limit: 500

--- a/modules/custom/dkan_sql_endpoint/dkan_sql_endpoint.info.yml
+++ b/modules/custom/dkan_sql_endpoint/dkan_sql_endpoint.info.yml
@@ -1,4 +1,4 @@
-name: SQL Enpoint
+name: SQL Endpoint
 description: 'An web services endpoint that allow SQL-like syntax to be used to interact with resources in the datastore.'
 type: module
 core: 8.x

--- a/modules/custom/dkan_sql_endpoint/dkan_sql_endpoint.links.menu.yml
+++ b/modules/custom/dkan_sql_endpoint/dkan_sql_endpoint.links.menu.yml
@@ -1,0 +1,5 @@
+dkan_sql_endpoint.settings_form:
+  title: SQL endpoint
+  route_name: dkan_sql_endpoint.settings
+  description: Configure SQL query API endpoint.
+  parent: dkan_common.admin_config_dkan

--- a/modules/custom/dkan_sql_endpoint/dkan_sql_endpoint.routing.yml
+++ b/modules/custom/dkan_sql_endpoint/dkan_sql_endpoint.routing.yml
@@ -5,3 +5,11 @@ dkan_sql_endpoint.api:
     { _controller: '\Drupal\dkan_sql_endpoint\Controller\Api::runQuery'}
   requirements:
     _access: 'TRUE'
+dkan_sql_endpoint.settings:
+  path: '/admin/config/dkan/sql_endpoint'
+  defaults:
+    _form: '\Drupal\dkan_sql_endpoint\Form\DkanSqlEndpointSettingsForm'
+  requirements:
+    _permission: 'access administration pages'
+  options:
+    _admin_route: TRUE

--- a/modules/custom/dkan_sql_endpoint/src/Form/DkanSqlEndpointSettingsForm.php
+++ b/modules/custom/dkan_sql_endpoint/src/Form/DkanSqlEndpointSettingsForm.php
@@ -5,6 +5,12 @@ namespace Drupal\dkan_sql_endpoint\Form;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 
+/**
+ * Class DkanSqlEndpointSettingsForm.
+ *
+ * @package Drupal\dkan_sql_endpoint\Form
+ * @codeCoverageIgnore
+ */
 class DkanSqlEndpointSettingsForm extends ConfigFormBase {
 
   /**

--- a/modules/custom/dkan_sql_endpoint/src/Form/DkanSqlEndpointSettingsForm.php
+++ b/modules/custom/dkan_sql_endpoint/src/Form/DkanSqlEndpointSettingsForm.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\dkan_sql_endpoint\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+class DkanSqlEndpointSettingsForm extends ConfigFormBase {
+
+  /**
+   * Inherited.
+   *
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'dkan_sql_endpoint_settings_form';
+  }
+
+  /**
+   * Inherited.
+   *
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'dkan_sql_endpoint.settings',
+    ];
+  }
+
+  /**
+   * Inherited.
+   *
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('dkan_sql_endpoint.settings');
+    $form['rows_limit'] = [
+      '#type' => 'number',
+      '#min' => 1,
+      '#max' => 9999,
+      '#title' => $this->t('Rows limit'),
+      '#default_value' => $config->get('rows_limit'),
+    ];
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * Inherited.
+   *
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+
+    $this->config('dkan_sql_endpoint.settings')
+      ->set('rows_limit', $form_state->getValue('rows_limit'))
+      ->save();
+  }
+
+}

--- a/modules/custom/dkan_sql_endpoint/tests/src/Unit/Controller/ApiTest.php
+++ b/modules/custom/dkan_sql_endpoint/tests/src/Unit/Controller/ApiTest.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\Tests\dkan_datastore\Unit\Controller;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\StorableConfigBase;
 use Drupal\Core\Database\Connection;
 use Drupal\dkan_common\Tests\DkanTestBase;
 use Drupal\dkan_datastore\Service\Datastore;
@@ -31,7 +33,8 @@ class ApiTest extends DkanTestBase {
       ->with(
         $this->logicalOr(
           $this->equalTo('database'),
-          $this->equalTo('dkan_datastore.service')
+          $this->equalTo('dkan_datastore.service'),
+          $this->equalTo('config.factory')
         )
       )
       ->will($this->returnCallback(function ($input) {
@@ -41,6 +44,9 @@ class ApiTest extends DkanTestBase {
 
           case 'dkan_datastore.service':
             return $this->getDatastoreMock();
+
+          case 'config.factory':
+            return $this->getConfigMock();
         }
       }));
 
@@ -131,6 +137,28 @@ class ApiTest extends DkanTestBase {
    */
   private function getDatastoreMock() {
     return $this->createMock(Datastore::class);
+  }
+
+  private function getConfigMock() {
+    $mock = $this->getMockBuilder(ConfigFactoryInterface::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['get'])
+      ->getMockForAbstractClass();
+
+    $mock->method('get')->willReturn($this->getConfigResultMock());
+
+    return $mock;
+  }
+
+  private function getConfigResultMock() {
+    $mock = $this->getMockBuilder(StorableConfigBase::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['get'])
+      ->getMockForAbstractClass();
+
+    $mock->method('get')->willReturn(10);
+
+    return $mock;
   }
 
 }


### PR DESCRIPTION
### Steps to test

1. Have a site with datasets and at least one datastore
1. Checkout this branch
1. Uninstall and reinstall the DKAN SQL Endpoint module
1. Visit `/admin/config/dkan/sql_endpoint` to verify the default limit number of rows (feel free to set it to something more conducive to manual testing)
1. Run some SQL query on your datastore via our endpoint (feel free to test several queries with their own LIMIT statements)