### PR TITLE
Dataset UUID resources endpoint

### DIFF
--- a/modules/custom/dkan_api/docs/dkan_api_openapi_spec.yml
+++ b/modules/custom/dkan_api/docs/dkan_api_openapi_spec.yml
@@ -271,7 +271,7 @@ paths:
   /api/v1/dataset/{uuid}/resources:
     get:
       operationId: dataset-get-resources
-      summary: Get resources for a particular dataset
+      summary: Get a dataset's resources
       tags:
         - Dataset
       parameters:

--- a/modules/custom/dkan_api/docs/dkan_api_openapi_spec.yml
+++ b/modules/custom/dkan_api/docs/dkan_api_openapi_spec.yml
@@ -291,6 +291,14 @@ paths:
                 type: array
                 items:
                   type: object
+                  required:
+                    - identifier
+                    - data
+                  properties:
+                    identifier:
+                      type: string
+                    data:
+                      type: object
   /api/v1/{property}:
     get:
       operationId: property-get-all

--- a/modules/custom/dkan_api/docs/dkan_api_openapi_spec.yml
+++ b/modules/custom/dkan_api/docs/dkan_api_openapi_spec.yml
@@ -268,6 +268,29 @@ paths:
                     type: string
         '401':
           description: Unauthorized
+  /api/v1/dataset/{uuid}/resources:
+    get:
+      operationId: dataset-get-resources
+      summary: Get resources for a particular dataset
+      tags:
+        - Dataset
+      parameters:
+        - name: uuid
+          in: path
+          description: A dataset uuid
+          required: true
+          schema:
+            type: string
+          example: c9e2d352-e24c-4051-9158-f48127aa5692
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
   /api/v1/{property}:
     get:
       operationId: property-get-all

--- a/modules/custom/dkan_api/src/Controller/Api.php
+++ b/modules/custom/dkan_api/src/Controller/Api.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\dkan_api\Controller;
 
+use Drupal\dkan_data\ValueReferencer;
 use Sae\Sae;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -105,6 +106,40 @@ class Api implements ContainerInjectionInterface {
 
       return new JsonResponse(
         json_decode($data),
+        200,
+        ["Access-Control-Allow-Origin" => "*"]
+      );
+    }
+    catch (\Exception $e) {
+      return new JsonResponse((object) ["message" => $e->getMessage()], 404);
+    }
+  }
+
+  /**
+   * GET all resources associated with a dataset.
+   *
+   * @param string $uuid
+   *   Identifier.
+   * @param string $schema_id
+   *   The {schema_id} slug from the HTTP request.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   The json response.
+   */
+  public function getResources($uuid, $schema_id) {
+
+    try {
+      // Load this dataset's metadata with both data and identifiers.
+      if (function_exists('drupal_static')) {
+        drupal_static('dkan_data_dereference_method', ValueReferencer::DEREFERENCE_OUTPUT_BOTH);
+      }
+
+      $data = $this->getEngine($schema_id)
+        ->get($uuid);
+      $distribution = json_decode($data)->distribution;
+
+      return new JsonResponse(
+        $distribution,
         200,
         ["Access-Control-Allow-Origin" => "*"]
       );

--- a/modules/custom/dkan_api/src/Routing/RouteProvider.php
+++ b/modules/custom/dkan_api/src/Routing/RouteProvider.php
@@ -66,6 +66,9 @@ class RouteProvider {
         // DELETE.
         $delete = $this->routeHelper($schema, "/api/v1/$schema/{uuid}", 'DELETE', 'delete');
         $authenticated_routes->add("dkan_api.{$schema}.delete", $delete);
+        // GET resources.
+        $get_resources = $this->routeHelper($schema, "/api/v1/$schema/{uuid}/resources", 'GET', 'getResources');
+        $public_routes->add("dkan_api.{$schema}.get_resources", $get_resources);
       }
     }
 

--- a/modules/custom/dkan_api/src/Routing/RouteProvider.php
+++ b/modules/custom/dkan_api/src/Routing/RouteProvider.php
@@ -43,42 +43,87 @@ class RouteProvider {
     $routes = new RouteCollection();
     $public_routes = new RouteCollection();
     $authenticated_routes = new RouteCollection();
-    $schemas = array_merge(['dataset'], $this->getPropertyList());
 
-    foreach ($schemas as $schema) {
-      // GET collection.
-      $get_all = $this->routeHelper($schema, "/api/v1/$schema", 'GET', 'getAll');
-      $public_routes->add("dkan_api.{$schema}.get_all", $get_all);
-      // GET individual.
-      $get = $this->routeHelper($schema, "/api/v1/$schema/{uuid}", 'GET', 'get');
-      $public_routes->add("dkan_api.{$schema}.get", $get);
-      // PUT.
-      $put = $this->routeHelper($schema, "/api/v1/$schema/{uuid}", 'PUT', 'put');
-      $authenticated_routes->add("dkan_api.{$schema}.put", $put);
-      // PATCH.
-      $patch = $this->routeHelper($schema, "/api/v1/$schema/{uuid}", 'PATCH', 'patch');
-      $authenticated_routes->add("dkan_api.{$schema}.patch", $patch);
-      // Only applicable to datasets.
-      if ($schema === 'dataset') {
-        // POST.
-        $post = $this->routeHelper($schema, "/api/v1/$schema", 'POST', 'post');
-        $authenticated_routes->add("dkan_api.{$schema}.post", $post);
-        // DELETE.
-        $delete = $this->routeHelper($schema, "/api/v1/$schema/{uuid}", 'DELETE', 'delete');
-        $authenticated_routes->add("dkan_api.{$schema}.delete", $delete);
-        // GET resources.
-        $get_resources = $this->routeHelper($schema, "/api/v1/$schema/{uuid}/resources", 'GET', 'getResources');
-        $public_routes->add("dkan_api.{$schema}.get_resources", $get_resources);
-      }
-    }
-
+    $public_routes->addCollection($this->datasetPublicRoutes());
+    $public_routes->addCollection($this->propertyPublicRoutes());
     $this->setPublicRoutesAccess($public_routes);
-    $this->setPrivateRoutesAccess($authenticated_routes);
-
     $routes->addCollection($public_routes);
+
+    $authenticated_routes->addCollection($this->datasetAuthenticatedRoutes());
+    $authenticated_routes->addCollection($this->propertyAuthenticatedRoutes());
+    $this->setPrivateRoutesAccess($authenticated_routes);
     $routes->addCollection($authenticated_routes);
 
     return $routes;
+  }
+
+  /**
+   * Private.
+   */
+  private function datasetPublicRoutes() {
+    $datasetPublic = new RouteCollection();
+    $datasetPublic->add("dkan_api.dataset.get_all", $this->routeHelper(
+      'dataset', 'dataset', 'GET', 'getAll')
+    );
+    $datasetPublic->add("dkan_api.dataset.get", $this->routeHelper(
+      'dataset', 'dataset/{uuid}', 'GET', 'get')
+    );
+    $datasetPublic->add("dkan_api.dataset.get_resources", $this->routeHelper(
+      'dataset', 'dataset/{uuid}/resources', 'GET', 'getResources')
+    );
+    return $datasetPublic;
+  }
+
+  /**
+   * Private.
+   */
+  private function datasetAuthenticatedRoutes() {
+    $datasetAuthenticated = new RouteCollection();
+    $datasetAuthenticated->add("dkan_api.dataset.post", $this->routeHelper(
+      'dataset', 'dataset', 'POST', 'post')
+    );
+    $datasetAuthenticated->add("dkan_api.dataset.put", $this->routeHelper(
+      'dataset', 'dataset/{uuid}', 'PUT', 'put')
+    );
+    $datasetAuthenticated->add("dkan_api.dataset.patch", $this->routeHelper(
+      'dataset', 'dataset/{uuid}', 'PATCH', 'patch')
+    );
+    $datasetAuthenticated->add("dkan_api.dataset.delete", $this->routeHelper(
+      'dataset', 'dataset/{uuid}', 'DELETE', 'delete')
+    );
+    return $datasetAuthenticated;
+  }
+
+  /**
+   * Private.
+   */
+  private function propertyPublicRoutes() {
+    $propertyPublic = new RouteCollection();
+    foreach ($this->getPropertyList() as $schema) {
+      $propertyPublic->add("dkan_api.{$schema}.get_all", $this->routeHelper(
+        $schema, $schema, 'GET', 'getAll')
+      );
+      $propertyPublic->add("dkan_api.{$schema}.get", $this->routeHelper(
+        $schema, "{$schema}/{uuid}", 'GET', 'get')
+      );
+    }
+    return $propertyPublic;
+  }
+
+  /**
+   * Private.
+   */
+  private function propertyAuthenticatedRoutes() {
+    $propertyAuthenticated = new RouteCollection();
+    foreach ($this->getPropertyList() as $schema) {
+      $propertyAuthenticated->add("dkan_api.{$schema}.put", $this->routeHelper(
+        $schema, "{$schema}/{uuid}", 'PUT', 'put')
+      );
+      $propertyAuthenticated->add("dkan_api.{$schema}.patch", $this->routeHelper(
+        $schema, "{$schema}/{uuid}", 'PATCH', 'patch')
+      );
+    }
+    return $propertyAuthenticated;
   }
 
   /**
@@ -101,7 +146,7 @@ class RouteProvider {
    */
   private function routeHelper(string $schema, string $path, string $httpVerb, string $datasetMethod) : Route {
     $route = new Route(
-          $path,
+      "/api/v1/{$path}",
           [
             '_controller' => '\Drupal\dkan_api\Controller\Api::' . $datasetMethod,
             'schema_id' => $schema,

--- a/modules/custom/dkan_api/tests/src/Unit/Controller/ApiTest.php
+++ b/modules/custom/dkan_api/tests/src/Unit/Controller/ApiTest.php
@@ -58,12 +58,24 @@ class ApiTest extends TestCase {
   /**
    *
    */
-  public function testGetException() {
+  public function testGetResourcesException() {
     $mockChain = $this->getCommonMockChain();;
     $mockChain->add(Data::class, 'retrieve', new \Exception("bad"));
 
     $controller = Api::create($mockChain->getMock());
     $response = $controller->get(1, 'dataset');
+    $this->assertEquals('{"message":"bad"}', $response->getContent());
+  }
+
+  /**
+   *
+   */
+  public function testGetException() {
+    $mockChain = $this->getCommonMockChain();;
+    $mockChain->add(Data::class, 'retrieve', new \Exception("bad"));
+
+    $controller = Api::create($mockChain->getMock());
+    $response = $controller->getResources(1, 'dataset');
     $this->assertEquals('{"message":"bad"}', $response->getContent());
   }
 

--- a/modules/custom/dkan_api/tests/src/Unit/Controller/ApiTest.php
+++ b/modules/custom/dkan_api/tests/src/Unit/Controller/ApiTest.php
@@ -45,6 +45,19 @@ class ApiTest extends TestCase {
   /**
    *
    */
+  public function testGetResources() {
+    $mockChain = $this->getCommonMockChain();
+    $json = '{"name": "hello", "distribution": [{"title": "Foo"}, {"title": "Bar"}]}';
+    $mockChain->add(Data::class, 'retrieve', json_encode($json));
+
+    $controller = Api::create($mockChain->getMock());
+    $response = $controller->getResources(1, 'dataset');
+    $this->assertEquals('[{"title":"Foo"},{"title":"Bar"}]', $response->getContent());
+  }
+
+  /**
+   *
+   */
   public function testGetException() {
     $mockChain = $this->getCommonMockChain();;
     $mockChain->add(Data::class, 'retrieve', new \Exception("bad"));

--- a/modules/custom/dkan_api/tests/src/Unit/Routing/RouteProviderTest.php
+++ b/modules/custom/dkan_api/tests/src/Unit/Routing/RouteProviderTest.php
@@ -41,6 +41,7 @@ class RouteProviderTest extends TestCase {
         $route->getPath(),
         $this->logicalOr(
           $this->equalTo("/api/v1/dataset/{uuid}"),
+          $this->equalTo("/api/v1/dataset/{uuid}/resources"),
           $this->equalTo("/api/v1/dataset"),
           $this->equalTo("/api/v1/theme/{uuid}"),
           $this->equalTo("/api/v1/theme")


### PR DESCRIPTION
Adds an `api/v1/dataset/{uuid}/resources` endpoint, including:

- Documentation
- Dredd automated testing
- Unit tests
- Refactored dkan_api's routes() to lower code climate code complexity