### PR TITLE
Rename the dereferencing query parameter and its values

### DIFF
--- a/cypress/integration/api.spec.js
+++ b/cypress/integration/api.spec.js
@@ -74,7 +74,7 @@ context('API', () => {
 
     context('Dereference methods', () => {
         it('bad query parameter', () => {
-            cy.request(endpoint + '/' + json1.identifier + '?values=foobar').then((response) => {
+            cy.request(endpoint + '/' + json1.identifier + '?view=foobar').then((response) => {
                 expect(response.body.keyword).eql(json1.keyword)
             })
         })
@@ -86,13 +86,13 @@ context('API', () => {
         })
 
         it('data (explicit)', () => {
-            cy.request(endpoint + '/' + json1.identifier + '?values=data').then((response) => {
+            cy.request(endpoint + '/' + json1.identifier + '?view=default').then((response) => {
                 expect(response.body.keyword).eql(json1.keyword)
             })
         })
 
         it('identifier', () => {
-            cy.request(endpoint + '/' + json1.identifier + '?values=identifier').then((response) => {
+            cy.request(endpoint + '/' + json1.identifier + '?view=minimal').then((response) => {
                 expect(response.body.keyword).not.eql(json1.keyword)
                 expect(response.body.keyword.length).eql(json1.keyword.length)
                 expect(response.body.keyword[0]).to.match(uuidRegex)
@@ -102,7 +102,7 @@ context('API', () => {
         })
 
         it('data+identifier', () => {
-            cy.request(endpoint + '/' + json1.identifier + '?values=both').then((response) => {
+            cy.request(endpoint + '/' + json1.identifier + '?view=verbose').then((response) => {
                 expect(response.body.keyword).not.eql(json1.keyword)
                 expect(response.body.keyword.length).eql(json1.keyword.length)
                 expect(response.body.keyword[0].identifier).to.match(uuidRegex)

--- a/cypress/integration/datastore.spec.js
+++ b/cypress/integration/datastore.spec.js
@@ -20,7 +20,7 @@ context('Datastore API', () => {
   };
 
   before(() => {
-    cy.request(dataset_endpoint + '/' + dataset_identifier + '?values=both').then((response) => {
+    cy.request(dataset_endpoint + '/' + dataset_identifier + '?view=verbose').then((response) => {
       resource_identifier = response.body.distribution[0].identifier
     })
   })

--- a/cypress/integration/sqlendpoint.spec.js
+++ b/cypress/integration/sqlendpoint.spec.js
@@ -12,7 +12,7 @@ context('SQL Endpoint', () => {
     // Obtain the resource identifier from the above dataset before proceeding.
     before(function() {
         let uuidRegex = /^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/;
-        cy.request("http://dkan/api/v1/dataset/" + dataset_identifier + "?values=identifier").then((response) => {
+        cy.request("http://dkan/api/v1/dataset/" + dataset_identifier + "?view=minimal").then((response) => {
             expect(response.body.distribution[0]).not.eql(dataset_identifier)
             expect(response.body.distribution[0]).to.match(uuidRegex);
             resource_identifier = response.body.distribution[0];

--- a/modules/custom/dkan_api/src/Controller/Api.php
+++ b/modules/custom/dkan_api/src/Controller/Api.php
@@ -131,7 +131,7 @@ class Api implements ContainerInjectionInterface {
     try {
       // Load this dataset's metadata with both data and identifiers.
       if (function_exists('drupal_static')) {
-        drupal_static('dkan_data_dereference_method', ValueReferencer::DEREFERENCE_OUTPUT_BOTH);
+        drupal_static('dkan_data_dereference_method', ValueReferencer::DEREFERENCE_OUTPUT_VERBOSE);
       }
 
       $json = $this->getEngine($schema_id)

--- a/modules/custom/dkan_api/src/Controller/Docs.php
+++ b/modules/custom/dkan_api/src/Controller/Docs.php
@@ -258,7 +258,7 @@ class Docs implements ContainerInjectionInterface {
   private function replaceDistributions(array $spec, string $uuid) {
     // Load this dataset's metadata with both data and identifiers.
     if (function_exists('drupal_static')) {
-      drupal_static('dkan_data_dereference_method', ValueReferencer::DEREFERENCE_OUTPUT_BOTH);
+      drupal_static('dkan_data_dereference_method', ValueReferencer::DEREFERENCE_OUTPUT_VERBOSE);
     }
     $dataset = $this->storage->retrieve($uuid);
     $data = json_decode($dataset);

--- a/modules/custom/dkan_data/dkan_data.module
+++ b/modules/custom/dkan_data/dkan_data.module
@@ -34,24 +34,24 @@ function dkan_data_node_load(array $entities) {
  *
  * @return int
  *   One of the int constants from class ValueReferencer:
- *     - DEREFERENCE_OUTPUT_DATA = 0 (default case)
- *     - DEREFERENCE_OUTPUT_IDENTIFIER = 1
- *     - DEREFERENCE_OUTPUT_BOTH = 2
+ *     - DEREFERENCE_OUTPUT_DEFAULT = 0
+ *     - DEREFERENCE_OUTPUT_MINIMAL = 1
+ *     - DEREFERENCE_OUTPUT_VERBOSE = 2
  */
 function dereferencing_method() : int {
   $allowed_methods = [
-    ValueReferencer::DEREFERENCE_OUTPUT_DATA,
-    ValueReferencer::DEREFERENCE_OUTPUT_IDENTIFIER,
-    ValueReferencer::DEREFERENCE_OUTPUT_BOTH,
+    ValueReferencer::DEREFERENCE_OUTPUT_DEFAULT,
+    ValueReferencer::DEREFERENCE_OUTPUT_MINIMAL,
+    ValueReferencer::DEREFERENCE_OUTPUT_VERBOSE,
   ];
 
   // Selection based on API's http request query parameters.
   $params = Drupal::request()->query->all();
-  if (isset($params['values']) && $params['values'] == 'both') {
-    return ValueReferencer::DEREFERENCE_OUTPUT_BOTH;
+  if (isset($params['view']) && $params['view'] == 'verbose') {
+    return ValueReferencer::DEREFERENCE_OUTPUT_VERBOSE;
   }
-  if (isset($params['values']) && $params['values'] == 'identifier') {
-    return ValueReferencer::DEREFERENCE_OUTPUT_IDENTIFIER;
+  if (isset($params['view']) && $params['view'] == 'minimal') {
+    return ValueReferencer::DEREFERENCE_OUTPUT_MINIMAL;
   }
 
   // Selection based on static variable.
@@ -61,7 +61,7 @@ function dereferencing_method() : int {
   }
 
   // Default case.
-  return ValueReferencer::DEREFERENCE_OUTPUT_DATA;
+  return ValueReferencer::DEREFERENCE_OUTPUT_DEFAULT;
 }
 
 /**

--- a/modules/custom/dkan_data/src/ValueReferencer.php
+++ b/modules/custom/dkan_data/src/ValueReferencer.php
@@ -22,21 +22,21 @@ class ValueReferencer {
    *
    * @var int
    */
-  const DEREFERENCE_OUTPUT_DATA = 0;
+  const DEREFERENCE_OUTPUT_DEFAULT = 0;
 
   /**
    * Indicates that dereferencing outputs the identifier (uuid).
    *
    * @var int
    */
-  const DEREFERENCE_OUTPUT_IDENTIFIER = 1;
+  const DEREFERENCE_OUTPUT_MINIMAL = 1;
 
   /**
    * Indicates that dereferencing outputs both the data and its uuid.
    *
    * @var int
    */
-  const DEREFERENCE_OUTPUT_BOTH = 2;
+  const DEREFERENCE_OUTPUT_VERBOSE = 2;
 
   /**
    * Store the dereferencing method for current request.
@@ -262,9 +262,9 @@ class ValueReferencer {
    * @return mixed
    *   Modified json metadata object.
    */
-  public function dereference(stdClass $data, int $method = self::DEREFERENCE_OUTPUT_DATA) {
+  public function dereference(stdClass $data, int $method = self::DEREFERENCE_OUTPUT_DEFAULT) {
     // Skip data dereferencing when only seeking identifiers.
-    if ($method == self::DEREFERENCE_OUTPUT_IDENTIFIER) {
+    if ($method == self::DEREFERENCE_OUTPUT_MINIMAL) {
       return $data;
     }
 
@@ -340,7 +340,7 @@ class ValueReferencer {
     if ($node = reset($nodes)) {
       if (isset($node->field_json_metadata->value)) {
         $metadata = json_decode($node->field_json_metadata->value);
-        if ($this->dereferenceMethod == self::DEREFERENCE_OUTPUT_BOTH) {
+        if ($this->dereferenceMethod == self::DEREFERENCE_OUTPUT_VERBOSE) {
           return $metadata;
         }
         else {

--- a/modules/custom/dkan_data/tests/src/Unit/ValueReferencerTest.php
+++ b/modules/custom/dkan_data/tests/src/Unit/ValueReferencerTest.php
@@ -718,7 +718,7 @@ class ValueReferencerTest extends DkanTestBase {
       'another to dereference' => $uuid2,
       'other property' => 'Some other value',
     ];
-    // DEREFERENCE_OUTPUT_IDENTIFIER.
+    // DEREFERENCE_OUTPUT_MINIMAL.
     $method = 1;
 
     // Assert the dereferencing left the data unchanged, with identifiers.

--- a/modules/custom/dkan_datastore/src/Drush/Commands.php
+++ b/modules/custom/dkan_datastore/src/Drush/Commands.php
@@ -50,7 +50,7 @@ class Commands extends DrushCommands {
 
     try {
       // Load metadata with both identifier and data for this request.
-      drupal_static('dkan_data_dereference_method', ValueReferencer::DEREFERENCE_OUTPUT_BOTH);
+      drupal_static('dkan_data_dereference_method', ValueReferencer::DEREFERENCE_OUTPUT_VERBOSE);
 
       $this->datastoreService->import($uuid, $deferred);
     }
@@ -104,7 +104,7 @@ class Commands extends DrushCommands {
   public function drop($uuid) {
     try {
       // Load metadata with both identifier and data for this request.
-      drupal_static('dkan_data_dereference_method', ValueReferencer::DEREFERENCE_OUTPUT_BOTH);
+      drupal_static('dkan_data_dereference_method', ValueReferencer::DEREFERENCE_OUTPUT_VERBOSE);
       $this->datastoreService->drop($uuid);
     }
     catch (\Exception $e) {


### PR DESCRIPTION
- Rename query parameter `values` to `view`, and its possible values `both|identifier|data` to `verbose|minimal|default` respectively.
- Fix Cypress tests
- Passes Cypress and Dredd tests

Note: A similar PR should address the same changes in the frontend.