### PR TITLE
Switch to predictable UUID hashing for property references

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "getdkan/lunr.php": "~1.0.0",
         "guzzlehttp/guzzle" : "6.3",
         "ezyang/htmlpurifier" : "~4.11",
+        "ramsey/uuid" : "^3.8.0",
         "oomphinc/composer-installers-extender": "~1.1"
     },
     "require-dev": {

--- a/modules/custom/dkan_data/dkan_data.services.yml
+++ b/modules/custom/dkan_data/dkan_data.services.yml
@@ -14,3 +14,5 @@ services:
     class: \Drupal\dkan_data\ConfigurationOverrider
     tags:
       - {name: config.factory.override, priority: 5}
+  dkan_data.uuid5:
+    class: Drupal\dkan_data\Service\Uuid5

--- a/modules/custom/dkan_data/dkan_data.services.yml
+++ b/modules/custom/dkan_data/dkan_data.services.yml
@@ -7,7 +7,7 @@ services:
     class: \Drupal\dkan_data\ValueReferencer
     arguments:
       - '@entity_type.manager'
-      - '@uuid'
+      - '@dkan_data.uuid5'
       - '@config.factory'
       - '@queue'
   dkan_data.config_overrider:

--- a/modules/custom/dkan_data/src/Service/Uuid5.php
+++ b/modules/custom/dkan_data/src/Service/Uuid5.php
@@ -8,23 +8,30 @@ use Ramsey\Uuid\Uuid;
 
 /**
  * Service to generate predictable uuid's.
+ *
+ * We cannot solely rely on the data value. A keyword and a theme described
+ * by the same string must not end up being the same uuid, nor reference.
+ * Therefore, we create the named identifier from concatenating the schema id
+ * and the data value.
  */
 class Uuid5 {
 
   /**
    * Generate a uuid version 5.
    *
+   * @param $schema_id
+   *   The schema id of this value.
    * @param mixed $value
    *   The value for which we generate a uuid for.
    *
    * @return string
    *   The uuid.
    */
-  public function generate($value) {
+  public function generate($schema_id, $value) {
     if (!is_string($value)) {
       $value = json_encode($value, JSON_UNESCAPED_SLASHES);
     }
-    $uuid = Uuid::uuid5(Uuid::NAMESPACE_DNS, $value);
+    $uuid = Uuid::uuid5(Uuid::NAMESPACE_DNS, $schema_id . ":" . $value);
     return $uuid->toString();
   }
 

--- a/modules/custom/dkan_data/src/Service/Uuid5.php
+++ b/modules/custom/dkan_data/src/Service/Uuid5.php
@@ -19,7 +19,7 @@ class Uuid5 {
   /**
    * Generate a uuid version 5.
    *
-   * @param $schema_id
+   * @param string $schema_id
    *   The schema id of this value.
    * @param mixed $value
    *   The value for which we generate a uuid for.

--- a/modules/custom/dkan_data/src/Service/Uuid5.php
+++ b/modules/custom/dkan_data/src/Service/Uuid5.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\dkan_data\Service;
+
+use Ramsey\Uuid\Uuid;
+
+/**
+ * Service to generate predictable uuid's.
+ */
+class Uuid5 {
+
+  /**
+   * Generate a uuid version 5.
+   *
+   * @param mixed $value
+   *   The value for which we generate a uuid for.
+   *
+   * @return string
+   *   The uuid.
+   */
+  public function generate($value) {
+    if (!is_string($value)) {
+      $value = json_encode($value, JSON_UNESCAPED_SLASHES);
+    }
+    $uuid = Uuid::uuid5(Uuid::NAMESPACE_DNS, $value);
+    return $uuid->toString();
+  }
+
+}

--- a/modules/custom/dkan_data/src/ValueReferencer.php
+++ b/modules/custom/dkan_data/src/ValueReferencer.php
@@ -78,7 +78,7 @@ class ValueReferencer {
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   Injected entity type manager.
-   * @param \Drupal\Component\Uuid\UuidInterface $uuidService
+   * @param Drupal\dkan_data\Service\Uuid5 $uuidService
    *   Injected uuid service.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $configService
    *   Injected config service.

--- a/modules/custom/dkan_data/src/ValueReferencer.php
+++ b/modules/custom/dkan_data/src/ValueReferencer.php
@@ -6,7 +6,7 @@ namespace Drupal\dkan_data;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Component\Uuid\UuidInterface;
+use Drupal\dkan_data\Service\Uuid5;
 use Drupal\Core\Queue\QueueFactory;
 use stdClass;
 
@@ -85,7 +85,7 @@ class ValueReferencer {
    * @param \Drupal\Core\Queue\QueueFactory $queueService
    *   Injected queue service.
    */
-  public function __construct(EntityTypeManagerInterface $entityTypeManager, UuidInterface $uuidService, ConfigFactoryInterface $configService, QueueFactory $queueService) {
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, Uuid5 $uuidService, ConfigFactoryInterface $configService, QueueFactory $queueService) {
     $this->entityTypeManager = $entityTypeManager;
     $this->uuidService = $uuidService;
     $this->configService = $configService;
@@ -218,7 +218,7 @@ class ValueReferencer {
   protected function createPropertyReference(string $property_id, $value) {
     // Create json metadata for the reference.
     $data = new stdClass();
-    $data->identifier = $this->uuidService->generate();
+    $data->identifier = $this->uuidService->generate($property_id, $value);
     $data->data = $value;
 
     // Create node to store this reference.

--- a/modules/custom/dkan_data/tests/src/Unit/Service/Uuid5Test.php
+++ b/modules/custom/dkan_data/tests/src/Unit/Service/Uuid5Test.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\dkan_data\Tests\Unit;
+
+use Drupal\dkan_data\Service\Uuid5;
+use Drupal\dkan_common\Tests\DkanTestBase;
+
+/**
+ * Tests Drupal\dkan_data\Service\Uuid5.
+ *
+ * @coversDefaultClass \Drupal\dkan_data\Service\Uuid5
+ * @package Drupal\Tests\dkan_data\Unit\Service
+ * @group dkan_data
+ */
+class Uuid5Test extends DkanTestBase {
+
+  /**
+   * Test generate.
+   *
+   * @param string $schema_id
+   *   The schema id of this value.
+   * @param mixed $value
+   *   The value for which we generate a uuid for.
+   * @param string $expected
+   *   Expected value.
+   *
+   * @dataProvider generateProvider
+   */
+  public function testGenerate(string $schema_id, $value, $expected) {
+    // Assert.
+    $actual = Uuid5::generate($schema_id, $value);
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * Provide data for testGenerate.
+   *
+   * @return array
+   *   Schema id, value and expected.
+   */
+  public function generateProvider() {
+    return [
+      'string' => [
+        'foo',
+        'bar',
+        'fd088d96-7c6b-5adf-8581-cbb18a5dad67',
+      ],
+      'non-string' => [
+        'foo',
+        '{"bar":"baz"}',
+        'e9de513e-b4d7-5b05-902b-f90ee7a5db52',
+      ],
+    ];
+  }
+
+}

--- a/modules/custom/dkan_data/tests/src/Unit/Service/Uuid5Test.php
+++ b/modules/custom/dkan_data/tests/src/Unit/Service/Uuid5Test.php
@@ -49,7 +49,7 @@ class Uuid5Test extends DkanTestBase {
       ],
       'non-string' => [
         'foo',
-        '{"bar":"baz"}',
+        (object) ['bar' => 'baz'],
         'e9de513e-b4d7-5b05-902b-f90ee7a5db52',
       ],
     ];

--- a/modules/custom/dkan_data/tests/src/Unit/ValueReferencerTest.php
+++ b/modules/custom/dkan_data/tests/src/Unit/ValueReferencerTest.php
@@ -7,7 +7,7 @@ use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\dkan_common\Tests\DkanTestBase;
 use Drupal\dkan_data\ValueReferencer;
-use Drupal\Component\Uuid\UuidInterface;
+use Drupal\dkan_data\Service\Uuid5;
 use Drupal\Core\Queue\QueueFactory;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\node\NodeInterface;
@@ -33,7 +33,7 @@ class ValueReferencerTest extends DkanTestBase {
       ->getMock();
 
     $mockEntityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
-    $mockUuidInterface     = $this->createMock(UuidInterface::class);
+    $mockUuidInterface     = $this->createMock(Uuid5::class);
     $mockConfigInterface   = $this->createMock(ConfigFactoryInterface::class);
     $mockQueueFactory      = $this->createMock(QueueFactory::class);
 
@@ -130,7 +130,7 @@ class ValueReferencerTest extends DkanTestBase {
       ->setMethods(NULL)
       ->getMock();
 
-    $mockUuidInterface = $this->getMockBuilder(UuidInterface::class)
+    $mockUuidInterface = $this->getMockBuilder(Uuid5::class)
       ->disableOriginalConstructor()
       ->setMethods(
               [
@@ -168,7 +168,7 @@ class ValueReferencerTest extends DkanTestBase {
 
     $property_id = uniqid('some-property-');
     $value = uniqid('some-value-');
-    $uuid = uniqid('some-uuid-');
+    $uuid = Uuid5::generate($property_id, $value);
     $data = new stdClass();
     $data->identifier = $uuid;
     $data->data = $value;


### PR DESCRIPTION
One way to test could be to spin up the site twice, and verify that uuid's for references items (themes, keywords, distributions, publishers) remain the same. This can be done by doing the following requests, if testing on the old API:

{code}
http://dkan/api/v1/keyword
http://dkan/api/v1/theme
http://dkan/api/v1/distribution
http://dkan/api/v1/publisher
{code}

If this PR is tested after the API changes made it in master, then:

{code}
http://dkan/api/1/metastore/schemas/keyword/items
http://dkan/api/1/metastore/schemas/theme/items
http://dkan/api/1/metastore/schemas/distribution/items
http://dkan/api/1/metastore/schemas/publisher/items
{code}