### PR TITLE
Add drush as drupal dep

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,6 @@ jobs:
             fi'
             cat src/make/composer.json
             dktl make
-            dktl updatedrush -y
             rm -rf ./docroot/profiles/contrib/dkan2
             mv ~/project ./docroot/profiles/contrib/dkan2
             ls -lha ./docroot/profiles/contrib/dkan2

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "bower-asset/json-forms": "1.6.3",
         "composer/installers": "^1.2",
         "cweagans/composer-patches": "^1.5.0",
+        "drush/drush": "^9.7.1",
         "drupal/config_update": "1.x-dev",
         "drupal/entity": "1.0.0-rc1",
         "fmizzell/json_form": "dev-8.x-1.x",


### PR DESCRIPTION
Per https://docs.drush.org/en/master/install/, "it is recommended that Drupal sites be built using Composer, with Drush listed as a dependency. ".