### PR TITLE
Update Lunr endpoint with new versioning format

### DIFF
--- a/modules/custom/dkan_lunr/dkan_lunr.routing.yml
+++ b/modules/custom/dkan_lunr/dkan_lunr.routing.yml
@@ -1,5 +1,5 @@
 dkan_lunr.search:
-  path: '/api/v1/search-index.json'
+  path: '/api/1/lunr/search-index.json'
   defaults:
    { _controller: '\Drupal\dkan_lunr\Controller\ApiController::search'}
   requirements:


### PR DESCRIPTION
This PR updates the endpoint used for the frontend searches to match the new format of `api/1/<source>/endpoint` instead of the old `api/v1/endpoint`. This issue came up while testing the frontend against 3.0.0-rc1. 