### PR TITLE
Remove or replace outdated dereferencing methods

### DIFF
--- a/modules/custom/dkan_data/dkan_data.module
+++ b/modules/custom/dkan_data/dkan_data.module
@@ -35,8 +35,7 @@ function dkan_data_node_load(array $entities) {
  * @return int
  *   One of the int constants from class ValueReferencer:
  *     - DEREFERENCE_OUTPUT_DEFAULT = 0
- *     - DEREFERENCE_OUTPUT_MINIMAL = 1
- *     - DEREFERENCE_OUTPUT_VERBOSE = 2
+ *     - DEREFERENCE_OUTPUT_REFERENCE_IDS = 2
  */
 function dereferencing_method() : int {
   $allowed_methods = [

--- a/modules/custom/dkan_datastore/src/Drush.php
+++ b/modules/custom/dkan_datastore/src/Drush.php
@@ -50,7 +50,7 @@ class Drush extends DrushCommands {
 
     try {
       // Load metadata with both identifier and data for this request.
-      drupal_static('dkan_data_dereference_method', ValueReferencer::DEREFERENCE_OUTPUT_VERBOSE);
+      drupal_static('dkan_data_dereference_method', ValueReferencer::DEREFERENCE_OUTPUT_REFERENCE_IDS);
 
       $this->datastoreService->import($uuid, $deferred);
     }
@@ -104,7 +104,7 @@ class Drush extends DrushCommands {
   public function drop($uuid) {
     try {
       // Load metadata with both identifier and data for this request.
-      drupal_static('dkan_data_dereference_method', ValueReferencer::DEREFERENCE_OUTPUT_VERBOSE);
+      drupal_static('dkan_data_dereference_method', ValueReferencer::DEREFERENCE_OUTPUT_REFERENCE_IDS);
       $this->datastoreService->drop($uuid);
     }
     catch (\Exception $e) {

--- a/modules/custom/dkan_metastore/src/Controller/Api.php
+++ b/modules/custom/dkan_metastore/src/Controller/Api.php
@@ -155,7 +155,7 @@ class Api implements ContainerInjectionInterface {
     try {
       // Load this dataset's metadata with both data and identifiers.
       if (function_exists('drupal_static')) {
-        drupal_static('dkan_data_dereference_method', ValueReferencer::DEREFERENCE_OUTPUT_VERBOSE);
+        drupal_static('dkan_data_dereference_method', ValueReferencer::DEREFERENCE_OUTPUT_REFERENCE_IDS);
       }
 
       $json = $this->getEngine($schema_id)


### PR DESCRIPTION
Ran into the following error:

`Error: Undefined class constant 'DEREFERENCE_OUTPUT_VERBOSE' in /var/www/docroot/profiles/contrib/dkan2/modules/custom/dkan_datastore/src/Drush.php`

Which led me to replacing instances of `DEREFERENCE_OUTPUT_VERBOSE`, and even removing a `DEREFERENCE_OUTPUT_MINIMAL`.