### PR TITLE
Replace outdated api/v1/dataset/{uuid} path in code and unit tests

### DIFF
--- a/modules/custom/dkan_api/tests/src/Unit/Controller/DocsTest.php
+++ b/modules/custom/dkan_api/tests/src/Unit/Controller/DocsTest.php
@@ -60,7 +60,7 @@ class DocsTest extends DkanTestBase {
     $controller = Docs::create($this->getContainer());
     $response = $controller->getComplete();
 
-    $spec = '{"openapi":"3.0.1","info":{"title":"API Documentation","version":"Alpha"},"paths":{"\/api\/v1\/dataset\/{uuid}":{"get":{"summary":"Get this dataset","tags":["Dataset"],"parameters":[{"name":"uuid","in":"path","description":"Dataset uuid","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"Ok"}}}}}}';
+    $spec = '{"openapi":"3.0.1","info":{"title":"API Documentation","version":"Alpha"},"paths":{"\/api\/1\/metastore\/schemas\/dataset\/items\/{identifier}":{"get":{"summary":"Get this dataset","tags":["Dataset"],"parameters":[{"name":"identifier","in":"path","description":"Dataset uuid","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"Ok"}}}}}}';
 
     $this->assertEquals($spec, $response->getContent());
   }

--- a/modules/custom/dkan_api/tests/src/Unit/Controller/docs/dkan_api_openapi_spec.yml
+++ b/modules/custom/dkan_api/tests/src/Unit/Controller/docs/dkan_api_openapi_spec.yml
@@ -3,14 +3,14 @@ info:
   title: API Documentation
   version: Alpha
 paths:
-  /api/v1/dataset/{uuid}:
+  /api/1/metastore/schemas/dataset/items/{identifier}:
     get:
       summary: Get this dataset
       # description:
       tags:
         - Dataset
       parameters:
-        - name: "uuid"
+        - name: "identifier"
           in: "path"
           description: "Dataset uuid"
           required: true

--- a/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
+++ b/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
@@ -96,16 +96,16 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
     unset($spec['components']['securitySchemes']);
     // Remove required parameters, since now part of path.
     unset($spec['paths']['/api/v1/sql/{query}']['get']['parameters']);
-    unset($spec['paths']['/api/v1/dataset/{uuid}']['get']['parameters']);
+    unset($spec['paths']['/api/1/metastore/schemas/dataset/items/{identifier}']['get']['parameters']);
     // Keep only the tags needed, so remove the properties tag.
     $spec['tags'] = [
       ["name" => "Dataset"],
       ["name" => "SQL Query"],
     ];
     // Replace the dataset uuid placeholder.
-    if (isset($spec['paths']['/api/v1/dataset/{uuid}'])) {
-      $spec['paths']['/api/v1/dataset/' . $identifier] = $spec['paths']['/api/v1/dataset/{uuid}'];
-      unset($spec['paths']['/api/v1/dataset/{uuid}']);
+    if (isset($spec['paths']['/api/1/metastore/schemas/dataset/items/{identifier}'])) {
+      $spec['paths']['/api/1/metastore/schemas/dataset/items/' . $identifier] = $spec['paths']['/api/1/metastore/schemas/dataset/items/{identifier}'];
+      unset($spec['paths']['/api/1/metastore/schemas/dataset/items/{identifier}']);
     }
 
     // Replace the sql endpoint query placeholder.

--- a/modules/custom/dkan_metastore/tests/src/Unit/WebServiceApiDocsTest.php
+++ b/modules/custom/dkan_metastore/tests/src/Unit/WebServiceApiDocsTest.php
@@ -25,7 +25,7 @@ class WebServiceApiDocsTest extends TestCase {
     $controller = WebServiceApiDocs::create($mockChain->getMock());
     $response = $controller->getDatasetSpecific(1);
 
-    $spec = '{"openapi":"3.0.1","info":{"title":"API Documentation","version":"Alpha"},"paths":{"\/api\/v1\/dataset\/1":{"get":{"summary":"Get this dataset","tags":["Dataset"],"responses":{"200":{"description":"Ok"}}}}},"tags":[{"name":"Dataset"},{"name":"SQL Query"}]}';
+    $spec = '{"openapi":"3.0.1","info":{"title":"API Documentation","version":"Alpha"},"paths":{"\/api\/1\/metastore\/schemas\/dataset\/items\/1":{"get":{"summary":"Get this dataset","tags":["Dataset"],"responses":{"200":{"description":"Ok"}}}}},"tags":[{"name":"Dataset"},{"name":"SQL Query"}]}';
 
     $this->assertEquals($spec, $response->getContent());
   }

--- a/modules/custom/dkan_metastore/tests/src/Unit/docs/dkan_api_openapi_spec.yml
+++ b/modules/custom/dkan_metastore/tests/src/Unit/docs/dkan_api_openapi_spec.yml
@@ -3,14 +3,14 @@ info:
   title: API Documentation
   version: Alpha
 paths:
-  /api/v1/dataset/{uuid}:
+  /api/1/metastore/schemas/dataset/items/{identifier}:
     get:
       summary: Get this dataset
       # description:
       tags:
         - Dataset
       parameters:
-        - name: "uuid"
+        - name: "identifier"
           in: "path"
           description: "Dataset uuid"
           required: true


### PR DESCRIPTION
This replaces a remnant from an older version of the DKAN API.