### PR TITLE
Simplify process to create dataset-specific openapi docs

### DIFF
--- a/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
+++ b/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
@@ -117,7 +117,7 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
       }
       else {
         // Otherwise, discard unnecessary verbs.
-        foreach($operations as $operation => $details) {
+        foreach ($operations as $operation => $details) {
           if (!in_array($operation, $this->endpointsToKeep[$path])) {
             unset($spec['paths'][$path][$operation]);
           }

--- a/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
+++ b/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
@@ -124,9 +124,16 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
   }
 
   /**
+   * Filter the verbs on the current path.
+   *
    * @param array $operations
+   *   Operations (verbs) for the current path.
+   *
    * @param string $path
+   *   The path being processed.
+   *
    * @param array $spec
+   *   Our modified dataset-specific openapi spec.
    */
   private function filterOperationsInCurrentPath(array $operations, string $path, array &$spec) {
     // Otherwise, discard unnecessary verbs.

--- a/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
+++ b/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
@@ -116,20 +116,39 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
         unset($spec['paths'][$path]);
       }
       else {
-        // Otherwise, discard unnecessary verbs.
-        foreach ($operations as $operation => $details) {
-          if (!in_array($operation, $this->endpointsToKeep[$path])) {
-            unset($spec['paths'][$path][$operation]);
-          }
-        }
-        // Discard any newly-empty paths.
-        if (empty($spec['paths'][$path])) {
-          unset($spec['paths'][$path]);
-        }
+        $this->filterOperationsInCurrentPath($operations, $path,$spec);
+//        // Otherwise, discard unnecessary verbs.
+//        foreach ($operations as $operation => $details) {
+//          if (!in_array($operation, $this->endpointsToKeep[$path])) {
+//            unset($spec['paths'][$path][$operation]);
+//          }
+//        }
+//        // Discard any newly-empty paths.
+//        if (empty($spec['paths'][$path])) {
+//          unset($spec['paths'][$path]);
+//        }
       }
     }
 
     return $spec;
+  }
+
+  /**
+   * @param array $operations
+   * @param string $path
+   * @param array $spec
+   */
+  private function filterOperationsInCurrentPath(array $operations, string $path, array &$spec) {
+    // Otherwise, discard unnecessary verbs.
+    foreach ($operations as $operation => $details) {
+      if (!in_array($operation, $this->endpointsToKeep[$path])) {
+        unset($spec['paths'][$path][$operation]);
+      }
+    }
+    // Discard any newly-empty paths.
+    if (empty($spec['paths'][$path])) {
+      unset($spec['paths'][$path]);
+    }
   }
 
   /**

--- a/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
+++ b/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
@@ -128,10 +128,8 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
    *
    * @param array $operations
    *   Operations (verbs) for the current path.
-   *
    * @param string $path
    *   The path being processed.
-   *
    * @param array $spec
    *   Our modified dataset-specific openapi spec.
    */

--- a/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
+++ b/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
@@ -116,17 +116,7 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
         unset($spec['paths'][$path]);
       }
       else {
-        $this->filterOperationsInCurrentPath($operations, $path,$spec);
-//        // Otherwise, discard unnecessary verbs.
-//        foreach ($operations as $operation => $details) {
-//          if (!in_array($operation, $this->endpointsToKeep[$path])) {
-//            unset($spec['paths'][$path][$operation]);
-//          }
-//        }
-//        // Discard any newly-empty paths.
-//        if (empty($spec['paths'][$path])) {
-//          unset($spec['paths'][$path]);
-//        }
+        $this->filterOperationsInCurrentPath($operations, $path, $spec);
       }
     }
 


### PR DESCRIPTION
This PR proposes a refactoring of the WebServiceApiDocs class, where a couple things seemed awkward:

1. Having to know the complete list of paths and operations we did not want. Adding new paths to our API would break the dataset-specific doc or require these new paths to be removed as well, which seemed repetitive. We simplify the logic by flipping it: chose only what to keep, discarding anything else.
1. API paths and operations where treated and removed individually. It removed a verb everywhere, without allowing to keep a verb in one path but not another. Now paths and verbs are treated as a unit to describe one endpoint. More combinations are possible.