### PR TITLE
Improve dataset specific docs

### DIFF
--- a/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
+++ b/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
@@ -17,7 +17,7 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
   /**
    * List of endpoints to keep for dataset-specific docs.
    *
-   * Any combination of a path and any of its verbs not specifically listed
+   * Any combination of a path and any of its operations not specifically listed
    * below will be discarded.
    *
    * @var array
@@ -74,9 +74,9 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
    *   OpenAPI spec response.
    */
   public function getDatasetSpecific(string $identifier) {
-    $spec = $this->docsController->getJsonFromYmlFile();
+    $fullSpec = $this->docsController->getJsonFromYmlFile();
 
-    $spec = $this->keepDatasetSpecificEndpoints($spec);
+    $spec = $this->keepDatasetSpecificEndpoints($fullSpec, $this->endpointsToKeep);
 
     // Remove the security schemes.
     unset($spec['components']['securitySchemes']);
@@ -101,22 +101,24 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
   }
 
   /**
-   * Keep only paths and verbs relevant for our dataset-specific docs.
+   * Keep only paths and operations relevant for our dataset-specific docs.
    *
    * @param array $spec
    *   The original spec array.
+   * @param array $endpointsToKeep
+   *   List of endpoints to keep.
    *
    * @return array
    *   Modified spec.
    */
-  private function keepDatasetSpecificEndpoints(array $spec) {
+  private function keepDatasetSpecificEndpoints(array $spec, array $endpointsToKeep) {
+    $relevant_paths = array_keys($endpointsToKeep);
     foreach ($spec['paths'] as $path => $operations) {
-      // Discard unnecessary paths.
-      if (empty($this->endpointsToKeep[$path])) {
-        unset($spec['paths'][$path]);
+      if (in_array($path, $relevant_paths)) {
+        $this->filterOperationsInCurrentPath($operations, $path, $endpointsToKeep, $spec);
       }
       else {
-        $this->filterOperationsInCurrentPath($operations, $path, $spec);
+        unset($spec['paths'][$path]);
       }
     }
 
@@ -124,25 +126,22 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
   }
 
   /**
-   * Filter the verbs on the current path.
+   * Keep relevant operations on the current path.
    *
    * @param array $operations
-   *   Operations (verbs) for the current path.
+   *   Operations for the current path.
    * @param string $path
    *   The path being processed.
+   * @param array $endpointsToKeep
+   *   Array of endpoints (paths with operations) to keep.
    * @param array $spec
    *   Our modified dataset-specific openapi spec.
    */
-  private function filterOperationsInCurrentPath(array $operations, string $path, array &$spec) {
-    // Otherwise, discard unnecessary verbs.
+  private function filterOperationsInCurrentPath(array $operations, string $path, array $endpointsToKeep, array &$spec) {
     foreach ($operations as $operation => $details) {
-      if (!in_array($operation, $this->endpointsToKeep[$path])) {
+      if (!in_array($operation, $endpointsToKeep[$path])) {
         unset($spec['paths'][$path][$operation]);
       }
-    }
-    // Discard any newly-empty paths.
-    if (empty($spec['paths'][$path])) {
-      unset($spec['paths'][$path]);
     }
   }
 

--- a/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
+++ b/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
@@ -167,7 +167,7 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
     // Create and customize a path for each dataset distribution/resource.
     if (isset($data->distribution)) {
       foreach ($data->distribution as $dist) {
-        $path = "/api/1/datastore/sql/[SELECT * FROM {$dist->identifier}];";
+        $path = "/api/1/datastore/sql?query=[SELECT * FROM {$dist->identifier}];";
 
         $spec['paths'][$path] = $spec['paths']['/api/1/datastore/sql'];
         $spec['paths'][$path]['get']['summary'] = $dist->data->title ?? "";

--- a/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
+++ b/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
@@ -81,7 +81,7 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
     // Remove the security schemes.
     unset($spec['components']['securitySchemes']);
     // Remove required parameters, since now part of path.
-    unset($spec['paths']['/api/v1/sql/{query}']['get']['parameters']);
+    unset($spec['paths']['/api/1/datastore/sql']['get']['parameters']);
     unset($spec['paths']['/api/1/metastore/schemas/dataset/items/{identifier}']['get']['parameters']);
     // Keep only the tags needed, so remove the properties tag.
     $spec['tags'] = [
@@ -167,13 +167,13 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
     // Create and customize a path for each dataset distribution/resource.
     if (isset($data->distribution)) {
       foreach ($data->distribution as $dist) {
-        $path = "/api/v1/sql/[SELECT * FROM {$dist->identifier}];";
+        $path = "/api/1/datastore/sql/[SELECT * FROM {$dist->identifier}];";
 
-        $spec['paths'][$path] = $spec['paths']['/api/v1/sql/{query}'];
+        $spec['paths'][$path] = $spec['paths']['/api/1/datastore/sql'];
         $spec['paths'][$path]['get']['summary'] = $dist->data->title ?? "";
         $spec['paths'][$path]['get']['description'] = $dist->data->description ?? "";
       }
-      unset($spec['paths']['/api/v1/sql/{query}']);
+      unset($spec['paths']['/api/1/datastore/sql']);
     }
     return $spec;
   }

--- a/modules/custom/dkan_metastore/tests/src/Unit/WebServiceApiDocsTest.php
+++ b/modules/custom/dkan_metastore/tests/src/Unit/WebServiceApiDocsTest.php
@@ -22,6 +22,17 @@ class WebServiceApiDocsTest extends TestCase {
   public function testGetDatasetSpecific() {
     $mockChain = $this->getCommonMockChain();
 
+    // Test against ./docs/dkan_api_openapi_spec.yml
+    $endpointsToKeep = [
+      // Target paths.
+      '/api/1/metastore/schemas/dataset/items/{identifier}' => ['get'],
+      '/api/1/datastore/sql' => ['get'],
+      // Non-existent operation.
+      '/api/1/some/other/path' => ['get'],
+      // Non-existent path.
+      'api/1/non/existent/path' => ['put'],
+    ];
+
     $controller = WebServiceApiDocs::create($mockChain->getMock());
     $response = $controller->getDatasetSpecific(1);
 

--- a/modules/custom/dkan_metastore/tests/src/Unit/WebServiceApiDocsTest.php
+++ b/modules/custom/dkan_metastore/tests/src/Unit/WebServiceApiDocsTest.php
@@ -34,7 +34,7 @@ class WebServiceApiDocsTest extends TestCase {
     ];
 
     $controller = WebServiceApiDocs::create($mockChain->getMock());
-    $response = $controller->getDatasetSpecific(1);
+    $response = $controller->getDatasetSpecific(1, $endpointsToKeep);
 
     $spec = '{"openapi":"3.0.1","info":{"title":"API Documentation","version":"Alpha"},"paths":{"\/api\/1\/metastore\/schemas\/dataset\/items\/1":{"get":{"summary":"Get this dataset","tags":["Dataset"],"responses":{"200":{"description":"Ok"}}}}},"tags":[{"name":"Dataset"},{"name":"SQL Query"}]}';
 

--- a/modules/custom/dkan_metastore/tests/src/Unit/docs/dkan_api_openapi_spec.yml
+++ b/modules/custom/dkan_metastore/tests/src/Unit/docs/dkan_api_openapi_spec.yml
@@ -19,3 +19,18 @@ paths:
       responses:
         200:
           description: Ok
+    delete:
+      summary: This operation should not be present in dataset-specific docs.
+      responses:
+        200:
+          description: Ok
+    # Though an empty verb invalidates the spec, test its removal by dataset-specific docs.
+    post:
+  /api/1/some/other/path:
+    patch:
+      summary: This path and operation should not be present in dataset-specific docs.
+      responses:
+        200:
+          description: Ok
+  # Though an empty path invalidates the spec, test its removal by dataset-specific docs.
+  /api/1/path/without/operations:


### PR DESCRIPTION
PR fixes or improves the following:

1. Dataset-specific docs was mistakenly mentioning the old {{api/v1/sql}} endpoint, as seen here: <img width="930" alt="Screen Shot 2019-11-27 at 8 30 01 PM" src="https://user-images.githubusercontent.com/729791/69777345-bc29c300-1154-11ea-9339-d99bae4a191c.png">
1. Improves unit testing coverage, bumping to 100% in all but one function of class WebServiceApiDocs