### PR TITLE
Missing column title causing sql error during import

### DIFF
--- a/modules/custom/dkan_dummy_content/files/CDCSmokingRates.csv
+++ b/modules/custom/dkan_dummy_content/files/CDCSmokingRates.csv
@@ -1,4 +1,4 @@
-,State,% Smokers,Quality: Share of Smokers Who Have Tried to Quit,"Quality: Smoking-Attributable Deaths per Year (Per 100,000)",Quality:Costs Attributable to Smoking,Tax %
+State Abbreviation,State,% Smokers,Quality: Share of Smokers Who Have Tried to Quit,"Quality: Smoking-Attributable Deaths per Year (Per 100,000)",Quality:Costs Attributable to Smoking,Tax %
 AL,Alabama,22.5,47.1,321.1,3.55,0.43
 AK,Alaska,22.2,54.2,296.2,0.33,2
 AZ,Arizona,19.8,49.4,248.9,2.78,2


### PR DESCRIPTION
### Steps to reproduce

1. `dktl install`
1. `dktl drush dkan-dummy-content:create`
1. `dktl drush cron`

The output should include something similar (different UUID generated) to this, aside from the different UUID generated:

```
[error]  Import for ... returned an error: SQLSTATE[42000]:
Syntax error or access violation: 1166
Incorrect column name '': CREATE TABLE 
```

This PR addresses this error, by adding the missing column title in a CSV.