### PR TITLE
Add AmpOust and Socrata transform classes.

### DIFF
--- a/modules/custom/dkan_harvest/src/Transform/AmpOust.php
+++ b/modules/custom/dkan_harvest/src/Transform/AmpOust.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\dkan_harvest\Transform;
+
+use Harvest\ETL\Transform\Transform;
+
+/**
+ * Replaces "&" character with "and" in dataset title, keyword and theme.
+ */
+class AmpOust extends Transform {
+  /**
+   * Inherited.
+   *
+   * {@inheritDoc}
+   */
+  public function run($item) {
+    if ($item->theme) {
+      foreach ($item->theme as $key => $value) {
+        $item->theme[$key] = str_replace("&", "and", $item->theme[$key]);
+      }
+    }
+    if ($item->keyword) {
+      foreach ($item->keyword as $key => $value) {
+        $item->keyword[$key] = str_replace("&", "and", $item->keyword[$key]);
+      }
+    }
+    $item->title = str_replace("&", "and", $item->title);
+    return $item;
+  }
+
+}

--- a/modules/custom/dkan_harvest/src/Transform/Socrata.php
+++ b/modules/custom/dkan_harvest/src/Transform/Socrata.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\dkan_harvest\Transform;
+
+use Harvest\ETL\Transform\Transform;
+
+/**
+ * Class Socrata.
+ */
+class Socrata extends Transform {
+
+  /**
+   * Inherited.
+   *
+   * {@inheritDoc}
+   */
+  public function run($item) {
+
+    // Convert URL identifier to just the ID.
+    $identifier = $item->identifier;
+    $item->identifier = $this->getIdentifier($identifier);
+
+    // Add dummy keyword when keywords are null.
+    if (empty($item->keyword)) {
+      $item->keyword = ['No keywords provided'];
+    }
+
+    // Add dummy description if null.
+    if (empty($item->description)) {
+      $item->description = 'No description provided';
+    }
+
+    // Provide publisher name.
+    $publisher = $item->publisher;
+    if (!isset($publisher->name) && $publisher->source) {
+      $publisher->name = $publisher->source;
+    }
+
+    // Add titles for distributions if missing.
+    if ($item->distribution) {
+      $counter = 0;
+      foreach ($item->distribution as $key => $dist) {
+        if (empty($dist->title)) {
+          $dist->title = "{$identifier}_{$counter}";
+          $item->distribution[$key] = $dist;
+        }
+        $counter++;
+      }
+    }
+
+    return $item;
+  }
+
+  /**
+   * Private.
+   */
+  private function getIdentifier($identifier) {
+    $path = parse_url($identifier, PHP_URL_PATH);
+    $path = str_replace(['/api/views/', '/datasets/'], ["", ""], $path);
+    return $path;
+  }
+
+}


### PR DESCRIPTION
**AmpOust**: Titles with ampersands render as &amp; on Drupal sites, this class will replace "&" with "and" in dataset titles and theme values.

**Socrata**: Converts the url identifiers to standard ids. Adds titles to distributions if they are missing. And adds a dummy keyword if the keyword array is empty.

**QA steps**
```
dktl drush dkan-harvest:register '{"identifier":"tempe","extract":{"type":"\\Harvest\\ETL\\Extract\\DataJson","uri":"https://data.tempe.gov/data.json"},"transforms":["\\Drupal\\dkan_harvest\\Harvest\\Transform\\AmpOust"],"load":{"type":"\\Drupal\\dkan_harvest\\Load\\Dataset"}}'

dktl drush dkan-harvest:run tempe
```
- Confirm that the theme titles do not contain ampersands

```
dkan-harvest:register '{"identifier":"batonrouge","extract":{"type":"\\Harvest\\ETL\\Extract\\DataJson","uri":"https://data.brla.gov/data.json"},"transforms":["\\Drupal\\dkan_harvest\\Transform\\Socrata"],"load":{"type":"\\Drupal\\dkan_harvest\\Load\\Dataset"}}'

dktl drush dkan-harvest:run batonrouge
```

- Confirm that the identifiers are stripped to the ID value only
- Confirm that titles were added to the distributions

Needs tests