### PR TITLE
Permissions and endpoints for increased visibility

### DIFF
--- a/config/install/user.role.authenticated.yml
+++ b/config/install/user.role.authenticated.yml
@@ -13,3 +13,5 @@ permissions:
   - 'skip comment approval'
   - 'access site-wide contact form'
   - 'access shortcuts'
+  - 'metastore increased visibility'
+  - 'sql endpoint increased visibility'

--- a/modules/custom/dkan_data/dkan_data.services.yml
+++ b/modules/custom/dkan_data/dkan_data.services.yml
@@ -18,3 +18,5 @@ services:
       - {name: config.factory.override, priority: 5}
   dkan_data.uuid5:
     class: Drupal\dkan_data\Service\Uuid5
+  dkan_data.modifier:
+    class: \Drupal\dkan_data\Modifier

--- a/modules/custom/dkan_data/src/Modifier.php
+++ b/modules/custom/dkan_data/src/Modifier.php
@@ -29,4 +29,13 @@ class Modifier implements ModifierInterface {
     return $resources;
   }
 
+  /**
+   * Allows SQL query by default, can be modified with a decorator service.
+   *
+   * {@inheritDoc}
+   */
+  public function allowSqlQuery(): bool {
+    return TRUE;
+  }
+
 }

--- a/modules/custom/dkan_data/src/Modifier.php
+++ b/modules/custom/dkan_data/src/Modifier.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\dkan_data;
+
+/**
+ * Class Modifier.
+ *
+ * @package Drupal\dkan_data
+ */
+class Modifier implements ModifierInterface {
+
+  /**
+   * No changes by default, can be modified with a decorator service.
+   *
+   * {@inheritDoc}
+   */
+  public function modifyGet(string $schema_id, $data) {
+    return $data;
+  }
+
+  /**
+   * No changes by default, can be modified with a decorator service.
+   *
+   * {@inheritDoc}
+   */
+  public function modifyResources($resources) {
+    return $resources;
+  }
+
+}

--- a/modules/custom/dkan_data/src/ModifierInterface.php
+++ b/modules/custom/dkan_data/src/ModifierInterface.php
@@ -37,4 +37,12 @@ interface ModifierInterface {
    */
   public function modifyResources($resources);
 
+  /**
+   * Check if running an SQL query is allowed.
+   *
+   * @return bool
+   *   TRUE to allow the SQL Query, FALSE otherwise.
+   */
+  public function allowSqlQuery() : bool;
+
 }

--- a/modules/custom/dkan_data/src/ModifierInterface.php
+++ b/modules/custom/dkan_data/src/ModifierInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\dkan_data;
+
+/**
+ * Interface ModifierInterface.
+ *
+ * Potentially modify the output of unauthenticated metastore API requests.
+ *
+ * @package Drupal\dkan_data
+ */
+interface ModifierInterface {
+
+  /**
+   * Modify the output of Metastore's Get.
+   *
+   * @param string $schema_id
+   *   The {schema_id} slug from the HTTP request.
+   * @param mixed $data
+   *   The data whose output is to potentially be modified.
+   *
+   * @return mixed
+   *   The modified data.
+   */
+  public function modifyGet(string $schema_id, $data);
+
+  /**
+   * Modify the output of Metastore's getResources.
+   *
+   * @param mixed $resources
+   *   A dataset's resources.
+   *
+   * @return mixed
+   *   The modified resources.
+   */
+  public function modifyResources($resources);
+
+}

--- a/modules/custom/dkan_data/tests/src/Unit/ModifierTest.php
+++ b/modules/custom/dkan_data/tests/src/Unit/ModifierTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\Tests\dkan_data\Unit;
+
+use Drupal\dkan_data\Modifier;
+use PHPUnit\Framework\TestCase;
+
+class ModifierTest extends TestCase {
+
+  public function testModifyGet() {
+    $data = (object) ["foo" => "bar"];
+    $modifier = new Modifier();
+    $this->assertEquals($data, $modifier->modifyGet("baz", $data));
+  }
+
+  public function testModifyResources() {
+    $resources = [
+      (object) ["foo" => "bar"],
+      (object) ["foo" => "baz"],
+    ];
+    $modifier = new Modifier();
+    $this->assertEquals($resources, $modifier->modifyResources($resources));
+  }
+
+}

--- a/modules/custom/dkan_data/tests/src/Unit/ModifierTest.php
+++ b/modules/custom/dkan_data/tests/src/Unit/ModifierTest.php
@@ -22,4 +22,9 @@ class ModifierTest extends TestCase {
     $this->assertEquals($resources, $modifier->modifyResources($resources));
   }
 
+  public function testAllowSqlQuery() {
+    $modifier = new Modifier();
+    $this->assertEquals(TRUE, $modifier->allowSqlQuery());
+  }
+
 }

--- a/modules/custom/dkan_metastore/dkan_metastore.permissions.yml
+++ b/modules/custom/dkan_metastore/dkan_metastore.permissions.yml
@@ -1,3 +1,6 @@
 'post put delete datasets through the api':
   title: 'post, put, and delete datasets through the api'
   description: 'post, put, and delete datasets through the api'
+'metastore increased visibility':
+  title: 'Metastore: increased visibility'
+  description: 'View datasets or properties hidden from the public.'

--- a/modules/custom/dkan_metastore/dkan_metastore.routing.yml
+++ b/modules/custom/dkan_metastore/dkan_metastore.routing.yml
@@ -85,3 +85,23 @@ dkan_metastore.1.metastore.schemas.dataset.items.id.docs:
     { _controller: '\Drupal\dkan_metastore\WebServiceApiDocs::getDatasetSpecific'}
   requirements:
     _permission: 'access content'
+
+dkan_metastore.alt.1.metastore.schemas.id.items:
+  path: '/alt/api/1/metastore/schemas/{schema_id}/items'
+  methods: [GET]
+  defaults:
+    { _controller: '\Drupal\dkan_metastore\WebServiceApi::getAll'}
+  requirements:
+    _permission: 'metastore increased visibility'
+  options:
+    _auth: ['basic_auth']
+
+dkan_metastore.alt.1.metastore.schemas.id.items.id:
+  path: '/alt/api/1/metastore/schemas/{schema_id}/items/{identifier}'
+  methods: [GET]
+  defaults:
+    { _controller: '\Drupal\dkan_metastore\WebServiceApi::get'}
+  requirements:
+    _permission: 'metastore increased visibility'
+  options:
+    _auth: ['basic_auth']

--- a/modules/custom/dkan_metastore/dkan_metastore.services.yml
+++ b/modules/custom/dkan_metastore/dkan_metastore.services.yml
@@ -4,6 +4,7 @@ services:
     arguments:
       - '@dkan_schema.schema_retriever'
       - '@dkan_metastore.sae_factory'
+      - '@dkan_data.modifier'
   dkan_metastore.sae_factory:
     class: \Drupal\dkan_metastore\Factory\Sae
     arguments:

--- a/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
+++ b/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
@@ -25,7 +25,6 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
    */
   private $endpointsToKeep = [
     '/api/1/metastore/schemas/dataset/items/{identifier}' => ['get'],
-    '/api/1/datastore/sql' => ['get'],
   ];
 
   /**
@@ -88,6 +87,10 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
   public function getDatasetSpecific(string $identifier) {
     $fullSpec = $this->docsController->getJsonFromYmlFile();
 
+    // Docs to only include SQL endpoint if appropriate.
+    if ($this->modifier->allowSqlQuery()) {
+      $this->endpointsToKeep['/api/1/datastore/sql'] = ['get'];
+    }
     $spec = $this->keepDatasetSpecificEndpoints($fullSpec, $this->endpointsToKeep);
 
     // Remove the security schemes.

--- a/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
+++ b/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\dkan_metastore;
 
+use Drupal\dkan_data\ModifierInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\dkan_common\JsonResponseTrait;
@@ -42,12 +43,20 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
   private $metastoreService;
 
   /**
+   * Data modifier service.
+   *
+   * @var \Drupal\dkan_data\ModifierInterface
+   */
+  private $modifier;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
     return new WebServiceApiDocs(
       $container->get("dkan_api.docs"),
-      $container->get("dkan_metastore.service")
+      $container->get("dkan_metastore.service"),
+      $container->get("dkan_data.modifier")
     );
   }
 
@@ -58,10 +67,13 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
    *   Serves openapi spec for dataset-related endpoints.
    * @param \Drupal\dkan_metastore\Service $metastoreService
    *   Metastore service.
+   * @param \Drupal\dkan_data\ModifierInterface $modifier
+   *   Data modifier service.
    */
-  public function __construct(Docs $docsController, Service $metastoreService) {
+  public function __construct(Docs $docsController, Service $metastoreService, ModifierInterface $modifier) {
     $this->docsController = $docsController;
     $this->metastoreService = $metastoreService;
+    $this->modifier = $modifier;
   }
 
   /**

--- a/modules/custom/dkan_metastore/tests/src/Unit/ServiceTest.php
+++ b/modules/custom/dkan_metastore/tests/src/Unit/ServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\dkan_metastore\Unit;
 
+use Drupal\dkan_data\Modifier;
 use PHPUnit\Framework\TestCase;
 use Sae\Sae as Engine;
 use Drupal\Core\DependencyInjection\Container;
@@ -146,7 +147,8 @@ class ServiceTest extends TestCase {
   public function getCommonMockChain() {
     $options = (new Options())
       ->add('dkan_schema.schema_retriever', SchemaRetriever::class)
-      ->add('dkan_metastore.sae_factory', Sae::class);
+      ->add('dkan_metastore.sae_factory', Sae::class)
+      ->add('dkan_data.modifier', Modifier::class);
 
     return (new Chain($this))
       ->add(Container::class, "get", $options)

--- a/modules/custom/dkan_metastore/tests/src/Unit/WebServiceApiDocsTest.php
+++ b/modules/custom/dkan_metastore/tests/src/Unit/WebServiceApiDocsTest.php
@@ -21,7 +21,8 @@ class WebServiceApiDocsTest extends TestCase {
    *
    */
   public function testGetDatasetSpecific() {
-    $mockChain = $this->getCommonMockChain();
+    $mockChain = $this->getCommonMockChain()
+      ->add(ModifierInterface::class, 'allowSqlQuery', TRUE);
 
     // Test against ./docs/dkan_api_openapi_spec.yml.
     $endpointsToKeep = [

--- a/modules/custom/dkan_metastore/tests/src/Unit/WebServiceApiDocsTest.php
+++ b/modules/custom/dkan_metastore/tests/src/Unit/WebServiceApiDocsTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\dkan_metastore\Unit;
 
+use Drupal\dkan_data\ModifierInterface;
 use PHPUnit\Framework\TestCase;
 use Drupal\Core\Serialization\Yaml;
 use Drupal\dkan_api\Controller\Docs;
@@ -52,6 +53,7 @@ class WebServiceApiDocsTest extends TestCase {
     $mockChain->add(ContainerInterface::class, 'get',
       (new Options)->add('dkan_api.docs', Docs::class)
         ->add('dkan_metastore.service', Service::class)
+        ->add("dkan_data.modifier", ModifierInterface::class)
     )
       ->add(Docs::class, "getJsonFromYmlFile", $serializer->decode($yamlSpec))
       ->add(Service::class, "get", "{}");

--- a/modules/custom/dkan_sql_endpoint/dkan_sql_endpoint.permissions.yml
+++ b/modules/custom/dkan_sql_endpoint/dkan_sql_endpoint.permissions.yml
@@ -1,0 +1,3 @@
+'sql endpoint increased visibility':
+  title: 'SQL Endpoint: increased visibility'
+  description: 'View or query datastores hidden from the public.'

--- a/modules/custom/dkan_sql_endpoint/dkan_sql_endpoint.routing.yml
+++ b/modules/custom/dkan_sql_endpoint/dkan_sql_endpoint.routing.yml
@@ -20,3 +20,23 @@ dkan_sql_endpoint.settings:
     _permission: 'access administration pages'
   options:
     _admin_route: TRUE
+
+dkan_sql_endpoint.alt.get.api:
+  path: '/alt/api/1/datastore/sql'
+  methods: [GET]
+  defaults:
+    { _controller: '\Drupal\dkan_sql_endpoint\Controller\Api::runQueryGet'}
+  requirements:
+    _permission: 'sql endpoint increased visibility'
+  options:
+    _auth: ['basic_auth']
+
+dkan_sql_endpoint.alt.post.api:
+  path: '/alt/api/1/datastore/sql'
+  methods: [POST]
+  defaults:
+    { _controller: '\Drupal\dkan_sql_endpoint\Controller\Api::runQueryPost'}
+  requirements:
+    _permission: 'sql endpoint increased visibility'
+  options:
+    _auth: ['basic_auth']


### PR DESCRIPTION
- Adds new permissions for authenticated users for increased visibility
- Clone our normal public GET, GET all, and SQL endpoints, for now, but using the above permission and alternate URL starting with `/alt/api/1/...`

More later, but this part is independent and could be merged on its own without affecting anything.
