### PR TITLE
Refactor web service api docs

### DIFF
--- a/modules/custom/dkan_metastore/tests/src/Unit/WebServiceApiDocsTest.php
+++ b/modules/custom/dkan_metastore/tests/src/Unit/WebServiceApiDocsTest.php
@@ -25,7 +25,7 @@ class WebServiceApiDocsTest extends TestCase {
     $controller = WebServiceApiDocs::create($mockChain->getMock());
     $response = $controller->getDatasetSpecific(1);
 
-    $spec = '{"openapi":"3.0.1","info":{"title":"API Documentation","version":"Alpha"},"paths":{"\/api\/1\/metastore\/schemas\/dataset\/items\/1":{"get":{"summary":"Get this dataset","tags":["Dataset"],"responses":{"200":{"description":"Ok"}}}}},"tags":[{"name":"Dataset"}]}';
+    $spec = '{"openapi":"3.0.1","info":{"title":"API Documentation","version":"Alpha"},"tags":[{"name":"Dataset"},{"name":"SQL Query"}],"paths":{"\/api\/1\/datastore\/sql":{"get":{"summary":"Query resources","tags":["SQL Query"],"responses":{"200":{"description":"Ok"}}}},"\/api\/1\/metastore\/schemas\/dataset\/items\/1":{"get":{"summary":"Get this dataset","tags":["Dataset"],"responses":{"200":{"description":"Ok"}}}}}}';
 
     $this->assertEquals($spec, $response->getContent());
   }

--- a/modules/custom/dkan_metastore/tests/src/Unit/WebServiceApiDocsTest.php
+++ b/modules/custom/dkan_metastore/tests/src/Unit/WebServiceApiDocsTest.php
@@ -22,21 +22,10 @@ class WebServiceApiDocsTest extends TestCase {
   public function testGetDatasetSpecific() {
     $mockChain = $this->getCommonMockChain();
 
-    // Test against ./docs/dkan_api_openapi_spec.yml.
-    $endpointsToKeep = [
-      // Target paths.
-      '/api/1/metastore/schemas/dataset/items/{identifier}' => ['get'],
-      '/api/1/datastore/sql' => ['get'],
-      // Non-existent operation.
-      '/api/1/some/other/path' => ['get'],
-      // Non-existent path.
-      'api/1/non/existent/path' => ['put'],
-    ];
-
     $controller = WebServiceApiDocs::create($mockChain->getMock());
-    $response = $controller->getDatasetSpecific(1, $endpointsToKeep);
+    $response = $controller->getDatasetSpecific(1);
 
-    $spec = '{"openapi":"3.0.1","info":{"title":"API Documentation","version":"Alpha"},"paths":{"\/api\/1\/metastore\/schemas\/dataset\/items\/1":{"get":{"summary":"Get this dataset","tags":["Dataset"],"responses":{"200":{"description":"Ok"}}}}},"tags":[{"name":"Dataset"},{"name":"SQL Query"}]}';
+    $spec = '{"openapi":"3.0.1","info":{"title":"API Documentation","version":"Alpha"},"paths":{"\/api\/1\/metastore\/schemas\/dataset\/items\/1":{"get":{"summary":"Get this dataset","tags":["Dataset"],"responses":{"200":{"description":"Ok"}}}}},"tags":[{"name":"Dataset"}]}';
 
     $this->assertEquals($spec, $response->getContent());
   }
@@ -46,6 +35,7 @@ class WebServiceApiDocsTest extends TestCase {
    */
   private function getCommonMockChain() {
     $serializer = new Yaml();
+    // Test against ./docs/dkan_api_openapi_spec.yml.
     $yamlSpec = file_get_contents(__DIR__ . "/docs/dkan_api_openapi_spec.yml");
 
     $mockChain = new Chain($this);

--- a/modules/custom/dkan_metastore/tests/src/Unit/docs/dkan_api_openapi_spec.yml
+++ b/modules/custom/dkan_metastore/tests/src/Unit/docs/dkan_api_openapi_spec.yml
@@ -2,6 +2,10 @@ openapi: 3.0.1
 info:
   title: API Documentation
   version: Alpha
+tags:
+  - name: Dataset
+  - name: SQL Query
+  - name: Another Tag
 paths:
   /api/1/metastore/schemas/dataset/items/{identifier}:
     get:
@@ -26,6 +30,16 @@ paths:
           description: Ok
     # Though an empty verb invalidates the spec, test its removal by dataset-specific docs.
     post:
+  /api/1/datastore/sql:
+    get:
+      summary: Query resources
+      tags:
+        - SQL Query
+      parameters:
+        - $ref: '#/components/parameters/query'
+      responses:
+        '200':
+          description: Ok
   /api/1/some/other/path:
     patch:
       summary: This path and operation should not be present in dataset-specific docs.


### PR DESCRIPTION
Some refactoring to clean things up and ease hiding the SQL endpoint docs conditionally on plugins (i.e. non-public accessLevel) while maintaining code coverage.