### PR TITLE
Fix error in test of uuid5 service

### DIFF
--- a/modules/custom/dkan_data/tests/src/Unit/Service/Uuid5Test.php
+++ b/modules/custom/dkan_data/tests/src/Unit/Service/Uuid5Test.php
@@ -30,7 +30,7 @@ class Uuid5Test extends TestCase {
    */
   public function testGenerate(string $schema_id, $value, $expected) {
     // Assert.
-    $actual = Uuid5::generate($schema_id, $value);
+    $actual = (new Uuid5())->generate($schema_id, $value);
     $this->assertEquals($expected, $actual);
   }
 

--- a/modules/custom/dkan_data/tests/src/Unit/Service/Uuid5Test.php
+++ b/modules/custom/dkan_data/tests/src/Unit/Service/Uuid5Test.php
@@ -55,4 +55,14 @@ class Uuid5Test extends TestCase {
     ];
   }
 
+  public function testIsValid() {
+    $uuid5 = new Uuid5();
+
+    $valid = $uuid5->isValid('96f0603e-5da9-43e7-bc94-38eab002f9b3');
+    $this->assertTrue($valid);
+
+    $notValid = $uuid5->isValid('foo-bar');
+    $this->assertFalse($notValid);
+  }
+
 }


### PR DESCRIPTION
1. Address the 2 errors below, returned by PHPUnit on our Uuid5 service.
1. Increase test coverage to include Uuid5's `isValid()`.

```
1) Drupal\dkan_data\Tests\Unit\Uuid5Test::testGenerate with data set "string" ('foo', 'bar', 'fd088d96-7c6b-5adf-8581-cbb18a5dad67')
Non-static method Drupal\dkan_data\Service\Uuid5::generate() should not be called statically

/Users/thierry.dallacroce/Code/pqdc/docroot/profiles/contrib/dkan2/modules/custom/dkan_data/tests/src/Unit/Service/Uuid5Test.php:33

2) Drupal\dkan_data\Tests\Unit\Uuid5Test::testGenerate with data set "non-string" ('foo', stdClass Object (...), 'e9de513e-b4d7-5b05-902b-f90ee7a5db52')
Non-static method Drupal\dkan_data\Service\Uuid5::generate() should not be called statically

/Users/thierry.dallacroce/Code/pqdc/docroot/profiles/contrib/dkan2/modules/custom/dkan_data/tests/src/Unit/Service/Uuid5Test.php:33

ERRORS!
Tests: 2, Assertions: 0, Errors: 2.
```