### PR TITLE
Alternate API module

### DIFF
--- a/modules/custom/dkan_alt_api/dkan_alt_api.info.yml
+++ b/modules/custom/dkan_alt_api/dkan_alt_api.info.yml
@@ -1,0 +1,8 @@
+name: 'Alternate API'
+description: 'Provides alternate routes to access data potentially modified or restricted.'
+type: module
+core: 8.x
+package: DKAN
+dependencies:
+  - dkan_metastore
+  - dkan_sql_endpoint

--- a/modules/custom/dkan_alt_api/dkan_alt_api.permissions.yml
+++ b/modules/custom/dkan_alt_api/dkan_alt_api.permissions.yml
@@ -1,0 +1,6 @@
+'get data through the alternate metastore api':
+  title: 'Get data through the alternate metastore api'
+  description: 'Allows performing HTTP GET requests against the alternate metastore API endpoints.'
+'query the alternate sql endpoint api':
+  title: 'Query the alternate sql endpoint api'
+  description: 'Allows performing HTTP GET or POST requests against the alternate SQL API endpoints.'

--- a/modules/custom/dkan_alt_api/dkan_alt_api.routing.yml
+++ b/modules/custom/dkan_alt_api/dkan_alt_api.routing.yml
@@ -1,0 +1,39 @@
+dkan_alt_api.1.metastore.schemas.id.items:
+  path: '/alt/api/1/metastore/schemas/{schema_id}/items'
+  methods: [GET]
+  defaults:
+    { _controller: '\Drupal\dkan_metastore\WebServiceApi::getAll'}
+  requirements:
+    _permission: 'metastore increased visibility'
+  options:
+    _auth: ['basic_auth']
+
+dkan_alt_api.1.metastore.schemas.id.items.id:
+  path: '/alt/api/1/metastore/schemas/{schema_id}/items/{identifier}'
+  methods: [GET]
+  defaults:
+    { _controller: '\Drupal\dkan_metastore\WebServiceApi::get'}
+  requirements:
+    _permission: 'metastore increased visibility'
+  options:
+    _auth: ['basic_auth']
+
+dkan_alt_api.get.api:
+  path: '/alt/api/1/datastore/sql'
+  methods: [GET]
+  defaults:
+    { _controller: '\Drupal\dkan_sql_endpoint\Controller\Api::runQueryGet'}
+  requirements:
+    _permission: 'query the alternate sql endpoint api'
+  options:
+    _auth: ['basic_auth']
+
+dkan_alt_api.post.api:
+  path: '/alt/api/1/datastore/sql'
+  methods: [POST]
+  defaults:
+    { _controller: '\Drupal\dkan_sql_endpoint\Controller\Api::runQueryPost'}
+  requirements:
+    _permission: 'query the alternate sql endpoint api'
+  options:
+    _auth: ['basic_auth']


### PR DESCRIPTION
- Disabled by default
- New permissions, not tied to a role yet
- New endpoint URLs
- Re-uses the existing Metastore and SQL controllers