### PR TITLE
Feature/data modifier plugin

### DIFF
--- a/modules/custom/dkan_common/dkan_common.services.yml
+++ b/modules/custom/dkan_common/dkan_common.services.yml
@@ -1,5 +1,8 @@
 services:
-    dkan.factory:
-        class: Drupal\dkan_common\Service\Factory
-    dkan.json_util:
-        class: Drupal\dkan_common\Service\JsonUtil
+  dkan.factory:
+    class: Drupal\dkan_common\Service\Factory
+  dkan.json_util:
+    class: Drupal\dkan_common\Service\JsonUtil
+  plugin.manager.dkan_common.data_modifier:
+    class: \Drupal\dkan_common\Plugin\DataModifierManager
+    parent: default_plugin_manager

--- a/modules/custom/dkan_common/src/Annotation/DataModifier.php
+++ b/modules/custom/dkan_common/src/Annotation/DataModifier.php
@@ -29,4 +29,20 @@ class DataModifier extends Plugin {
    */
   public $label;
 
+  /**
+   * Communicate the plugin's effect on the modified data.
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   *
+   * @ingroup plugin_translatable
+   */
+  public $result;
+
+  /**
+   * HTTP code to include in response when modification has occured.
+   *
+   * @var int
+   */
+  public $resultCode;
+
 }

--- a/modules/custom/dkan_common/src/Annotation/DataModifier.php
+++ b/modules/custom/dkan_common/src/Annotation/DataModifier.php
@@ -5,7 +5,7 @@ namespace Drupal\dkan_common\Annotation;
 use Drupal\Component\Annotation\Plugin;
 
 /**
- * Defines an abstract base class for all data modifier plugin annotations.
+ * Annotation for data modifier plugins.
  *
  * @see plugin_api
  *

--- a/modules/custom/dkan_common/src/Annotation/DataModifier.php
+++ b/modules/custom/dkan_common/src/Annotation/DataModifier.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\dkan_common\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines an abstract base class for all data modifier plugin annotations.
+ *
+ * @see plugin_api
+ *
+ * @Annotation
+ */
+class DataModifier extends Plugin {
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * The label of the plugin.
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   *
+   * @ingroup plugin_translatable
+   */
+  public $label;
+
+}

--- a/modules/custom/dkan_common/src/DataModifierPluginTrait.php
+++ b/modules/custom/dkan_common/src/DataModifierPluginTrait.php
@@ -3,7 +3,7 @@
 namespace Drupal\dkan_common;
 
 /**
- * Provides common functionality for calls of data modifier plugins.
+ * Provides common functionality for alls data modifier plugins.
  */
 trait DataModifierPluginTrait {
 
@@ -29,7 +29,7 @@ trait DataModifierPluginTrait {
    *
    * @throws \Drupal\Component\Plugin\Exception\PluginException
    */
-  private function discoverDataModifierPlugins() {
+  private function discover() {
     $plugins = [];
     foreach ($this->pluginManager->getDefinitions() as $definition) {
       $plugins[] = $this->pluginManager->createInstance($definition['id']);

--- a/modules/custom/dkan_common/src/DataModifierPluginTrait.php
+++ b/modules/custom/dkan_common/src/DataModifierPluginTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\dkan_common;
+
+/**
+ * Provides common functionality for calls of data modifier plugins.
+ */
+trait DataModifierPluginTrait {
+
+  /**
+   * Data modifier plugin manager service.
+   *
+   * @var \Drupal\dkan_common\Plugin\DataModifierManager
+   */
+  private $pluginManager;
+
+  /**
+   * Instances of discovered data modifier plugins.
+   *
+   * @var array
+   */
+  private $plugins = [];
+
+  /**
+   * Discover data modifier plugins.
+   *
+   * @return array
+   *   A list of discovered data modifier plugins.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
+   */
+  private function discoverDataModifierPlugins() {
+    $plugins = [];
+    foreach ($this->pluginManager->getDefinitions() as $definition) {
+      $plugins[] = $this->pluginManager->createInstance($definition['id']);
+    }
+    return $plugins;
+  }
+
+}

--- a/modules/custom/dkan_common/src/Plugin/DataModifierBase.php
+++ b/modules/custom/dkan_common/src/Plugin/DataModifierBase.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\dkan_common\Plugin;
+
+use Drupal\Component\Plugin\PluginBase;
+
+/**
+ * Base class for Data modifier plugins.
+ */
+abstract class DataModifierBase extends PluginBase implements DataModifierInterface {
+
+  /**
+   * List of schemas to potentially modify. Others will be skipped.
+   *
+   * @var array
+   */
+  public $schemasToModify = [
+    'dataset',
+    'distribution',
+  ];
+
+}

--- a/modules/custom/dkan_common/src/Plugin/DataModifierBase.php
+++ b/modules/custom/dkan_common/src/Plugin/DataModifierBase.php
@@ -16,4 +16,24 @@ abstract class DataModifierBase extends PluginBase implements DataModifierInterf
    */
   private $schemasToModify = [];
 
+  /**
+   * Translate and render the result annotation.
+   *
+   * @return string
+   *   A message explaining the outcome.
+   */
+  public function message() : string {
+    return $this->getPluginDefinition()['result']->render();
+  }
+
+  /**
+   * Return the http code annotation.
+   *
+   * @return int
+   *   The http code.
+   */
+  public function httpCode() : int {
+    return (int) $this->getPluginDefinition()['code'];
+  }
+
 }

--- a/modules/custom/dkan_common/src/Plugin/DataModifierBase.php
+++ b/modules/custom/dkan_common/src/Plugin/DataModifierBase.php
@@ -5,7 +5,7 @@ namespace Drupal\dkan_common\Plugin;
 use Drupal\Component\Plugin\PluginBase;
 
 /**
- * Base class for Data modifier plugins.
+ * Defines an abstract base class for Data modifier plugins.
  */
 abstract class DataModifierBase extends PluginBase implements DataModifierInterface {
 
@@ -14,9 +14,6 @@ abstract class DataModifierBase extends PluginBase implements DataModifierInterf
    *
    * @var array
    */
-  public $schemasToModify = [
-    'dataset',
-    'distribution',
-  ];
+  private $schemasToModify = [];
 
 }

--- a/modules/custom/dkan_common/src/Plugin/DataModifierBase.php
+++ b/modules/custom/dkan_common/src/Plugin/DataModifierBase.php
@@ -10,13 +10,6 @@ use Drupal\Component\Plugin\PluginBase;
 abstract class DataModifierBase extends PluginBase implements DataModifierInterface {
 
   /**
-   * List of schemas to potentially modify. Others will be skipped.
-   *
-   * @var array
-   */
-  private $schemasToModify = [];
-
-  /**
    * Translate and render the result annotation.
    *
    * @return string

--- a/modules/custom/dkan_common/src/Plugin/DataModifierInterface.php
+++ b/modules/custom/dkan_common/src/Plugin/DataModifierInterface.php
@@ -41,4 +41,20 @@ interface DataModifierInterface extends PluginInspectionInterface {
    */
   public function modify(string $schema, $data);
 
+  /**
+   * Translate and render the result annotation.
+   *
+   * @return string
+   *   A message explaining the outcome.
+   */
+  public function message() : string;
+
+  /**
+   * Return the http code annotation.
+   *
+   * @return int
+   *   The http code.
+   */
+  public function httpCode() : int;
+
 }

--- a/modules/custom/dkan_common/src/Plugin/DataModifierInterface.php
+++ b/modules/custom/dkan_common/src/Plugin/DataModifierInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\dkan_common\Plugin;
+
+use Drupal\Component\Plugin\PluginInspectionInterface;
+
+/**
+ * Defines an interface for Data modifier plugins.
+ *
+ * Plugins of this type may have different conditions and outcomes, but all act
+ * on the following publicly accessible API endpoints:
+ *   - The metastore's GET collection and GET item
+ *   - The dataset-specific Api Docs
+ *   - The datastore's SQL query.
+ */
+interface DataModifierInterface extends PluginInspectionInterface {
+
+  /**
+   * Checks if the schema or data needs modifying.
+   *
+   * @param string $schema
+   *   The schema id.
+   * @param mixed $data
+   *   The data object, json string or identifier.
+   *
+   * @return bool
+   *   TRUE if the data requires modification, FALSE otherwise.
+   */
+  public function requiresModification(string $schema, $data);
+
+  /**
+   * Modify data.
+   *
+   * @param string $schema
+   *   The schema id.
+   * @param mixed $data
+   *   The object, json string or identifier whose data needs modifying.
+   *
+   * @return mixed
+   *   The modified data object, or FALSE.
+   */
+  public function modify(string $schema, $data);
+
+}

--- a/modules/custom/dkan_common/src/Plugin/DataModifierManager.php
+++ b/modules/custom/dkan_common/src/Plugin/DataModifierManager.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\dkan_common\Plugin;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+
+/**
+ * Manages data modifier plugins.
+ */
+class DataModifierManager extends DefaultPluginManager {
+
+  /**
+   * Constructs a new DataModifierManager object.
+   *
+   * @param \Traversable $namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   Cache backend instance to use.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler to invoke the alter hook with.
+   */
+  public function __construct(
+    \Traversable $namespaces,
+    CacheBackendInterface $cache_backend,
+    ModuleHandlerInterface $module_handler
+  ) {
+    parent::__construct(
+      'Plugin/DataModifier',
+      $namespaces,
+      $module_handler,
+      'Drupal\dkan_common\Plugin\DataModifierInterface',
+      'Drupal\dkan_common\Annotation\DataModifier'
+    );
+
+    $this->alterInfo('dkan_common_data_modifier_info');
+    $this->setCacheBackend($cache_backend, 'dkan_common_data_modifier_plugins');
+  }
+
+}

--- a/modules/custom/dkan_common/tests/src/Unit/Plugin/DataModifierManagerTest.php
+++ b/modules/custom/dkan_common/tests/src/Unit/Plugin/DataModifierManagerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\dkan_common\Tests\Unit;
+
+use Drupal\Core\Cache\MemoryBackend;
+use Drupal\Core\Extension\ModuleHandler;
+use Drupal\dkan_common\Plugin\DataModifierManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for class DataModifierManager.
+ *
+ * @package Drupal\dkan_common\Tests\Unit
+ */
+class DataModifierManagerTest extends TestCase {
+
+  /**
+   * Test constructor.
+   */
+  public function testDataModifierManager() {
+    $traversable = new \ArrayIterator();
+    $cache = new MemoryBackend();
+    $module = new ModuleHandler('blah', [], $cache);
+
+    $manager = new DataModifierManager($traversable, $cache, $module);
+    $this->assertTrue(is_object($manager));
+  }
+
+}

--- a/modules/custom/dkan_metastore/dkan_metastore.services.yml
+++ b/modules/custom/dkan_metastore/dkan_metastore.services.yml
@@ -4,7 +4,8 @@ services:
     arguments:
       - '@dkan_schema.schema_retriever'
       - '@dkan_metastore.sae_factory'
-      - '@plugin.manager.dkan_common.data_modifier'
+    calls:
+      - [setDataModifierPlugins, ['@plugin.manager.dkan_common.data_modifier']]
   dkan_metastore.sae_factory:
     class: \Drupal\dkan_metastore\Factory\Sae
     arguments:

--- a/modules/custom/dkan_metastore/dkan_metastore.services.yml
+++ b/modules/custom/dkan_metastore/dkan_metastore.services.yml
@@ -4,6 +4,7 @@ services:
     arguments:
       - '@dkan_schema.schema_retriever'
       - '@dkan_metastore.sae_factory'
+      - '@plugin.manager.dkan_common.data_modifier'
   dkan_metastore.sae_factory:
     class: \Drupal\dkan_metastore\Factory\Sae
     arguments:

--- a/modules/custom/dkan_metastore/src/Service.php
+++ b/modules/custom/dkan_metastore/src/Service.php
@@ -53,7 +53,7 @@ class Service implements ContainerInjectionInterface {
     $this->saeFactory = $saeFactory;
     $this->pluginManager = $pluginManager;
 
-    $this->plugins = $this->discoverDataModifierPlugins();
+    $this->plugins = $this->discover();
   }
 
   /**

--- a/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
+++ b/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\dkan_metastore;
 
+use Drupal\dkan_common\DataModifierPluginTrait;
+use Drupal\dkan_common\Plugin\DataModifierManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\dkan_common\JsonResponseTrait;
@@ -13,6 +15,7 @@ use Drupal\dkan_api\Controller\Docs;
  */
 class WebServiceApiDocs implements ContainerInjectionInterface {
   use JsonResponseTrait;
+  use DataModifierPluginTrait;
 
   /**
    * List of endpoints to keep for dataset-specific docs.
@@ -47,7 +50,8 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
   public static function create(ContainerInterface $container) {
     return new WebServiceApiDocs(
       $container->get("dkan_api.docs"),
-      $container->get("dkan_metastore.service")
+      $container->get("dkan_metastore.service"),
+      $container->get('plugin.manager.dkan_common.data_modifier')
     );
   }
 
@@ -58,10 +62,15 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
    *   Serves openapi spec for dataset-related endpoints.
    * @param \Drupal\dkan_metastore\Service $metastoreService
    *   Metastore service.
+   * @param \Drupal\dkan_common\Plugin\DataModifierManager $pluginManager
+   *   Metastore plugin manager.
    */
-  public function __construct(Docs $docsController, Service $metastoreService) {
+  public function __construct(Docs $docsController, Service $metastoreService, DataModifierManager $pluginManager) {
     $this->docsController = $docsController;
     $this->metastoreService = $metastoreService;
+    $this->pluginManager = $pluginManager;
+
+    $this->plugins = $this->discoverDataModifierPlugins();
   }
 
   /**
@@ -110,6 +119,26 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
   }
 
   /**
+   * Provides data modifiers plugins an opportunity to act.
+   *
+   * @param string $identifier
+   *   The distribution's identifier.
+   *
+   * @return bool
+   *   TRUE if sql endpoint docs needs to be protected, FALSE otherwise.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
+   */
+  private function modifyData(string $identifier) {
+    foreach ($this->plugins as $plugin) {
+      if ($plugin->requiresModification('distribution', $identifier)) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
    * Modify the generic sql endpoint to be specific to the current dataset.
    *
    * @param array $spec
@@ -121,7 +150,10 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
    *   Spec with dataset-specific datastore sql endpoint.
    */
   private function modifySqlEndpoint(array $spec, string $identifier) {
-    if (isset($spec['paths']['/api/1/datastore/sql'])) {
+    if ($this->modifyData($identifier)) {
+      unset($spec['paths']['/api/1/datastore/sql']);
+    }
+    elseif (isset($spec['paths']['/api/1/datastore/sql'])) {
       unset($spec['paths']['/api/1/datastore/sql']['get']['parameters']);
       $spec = $this->replaceDistributions($spec, $identifier);
       $spec['tags'][] = ["name" => "SQL Query"];
@@ -196,13 +228,35 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
     // Create and customize a path for each dataset distribution/resource.
     if (isset($data->distribution)) {
       foreach ($data->distribution as $dist) {
-        $path = "/api/1/datastore/sql?query=[SELECT * FROM {$dist->identifier}];";
-
-        $spec['paths'][$path] = $spec['paths']['/api/1/datastore/sql'];
-        $spec['paths'][$path]['get']['summary'] = $dist->data->title ?? "";
-        $spec['paths'][$path]['get']['description'] = $dist->data->description ?? "";
+        $spec = $this->replaceDistribution($dist, $spec, $identifier);
       }
       unset($spec['paths']['/api/1/datastore/sql']);
+    }
+    return $spec;
+  }
+
+  /**
+   * Replace a single distribution within the spec.
+   *
+   * @param mixed $dist
+   *   A distribution object.
+   * @param array $spec
+   *   The original spec array.
+   * @param string $identifier
+   *   The dataset uuid.
+   *
+   * @return array
+   *   Modified spec.
+   */
+  private function replaceDistribution($dist, array $spec, string $identifier) {
+    $path = "/api/1/datastore/sql?query=[SELECT * FROM {$dist->identifier}];";
+
+    $spec['paths'][$path] = $spec['paths']['/api/1/datastore/sql'];
+    if (isset($dist->data->title)) {
+      $spec['paths'][$path]['get']['summary'] = $dist->data->title;
+    }
+    if (isset($dist->data->description)) {
+      $spec['paths'][$path]['get']['description'] = $dist->data->description;
     }
     return $spec;
   }

--- a/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
+++ b/modules/custom/dkan_metastore/src/WebServiceApiDocs.php
@@ -70,7 +70,7 @@ class WebServiceApiDocs implements ContainerInjectionInterface {
     $this->metastoreService = $metastoreService;
     $this->pluginManager = $pluginManager;
 
-    $this->plugins = $this->discoverDataModifierPlugins();
+    $this->plugins = $this->discover();
   }
 
   /**

--- a/modules/custom/dkan_metastore/tests/src/Unit/ServiceTest.php
+++ b/modules/custom/dkan_metastore/tests/src/Unit/ServiceTest.php
@@ -2,8 +2,6 @@
 
 namespace Drupal\Tests\dkan_metastore\Unit;
 
-use Drupal\dkan_common\Plugin\DataModifierBase;
-use Drupal\dkan_common\Plugin\DataModifierManager;
 use PHPUnit\Framework\TestCase;
 use Sae\Sae as Engine;
 use Drupal\Core\DependencyInjection\Container;
@@ -56,20 +54,13 @@ class ServiceTest extends TestCase {
    *
    */
   public function testGet() {
-    $json = json_encode(['foo' => 'bar']);
-    $protected = (object) ['foo' => 'bar', 'protected' => 'processed'];
-
     $container = $this->getCommonMockChain()
       ->add(Sae::class, "getInstance", Engine::class)
-      ->add(Engine::class, "get", $json)
-      ->add(DataModifierManager::class, 'getDefinitions', [['id' => 'foobar']])
-      ->add(DataModifierManager::class, 'createInstance', DataModifierBase::class)
-      ->add(DataModifierBase::class, 'requiresModification', TRUE)
-      ->add(DataModifierBase::class, 'modify', $protected);
+      ->add(Engine::class, "get", json_encode("blah"));
 
     $service = Service::create($container->getMock());
 
-    $this->assertEquals(json_encode(['foo' => 'bar', 'protected' => 'processed']), $service->get("dataset", "1"));
+    $this->assertEquals(json_encode("blah"), $service->get("dataset", "1"));
   }
 
   /**
@@ -155,13 +146,11 @@ class ServiceTest extends TestCase {
   public function getCommonMockChain() {
     $options = (new Options())
       ->add('dkan_schema.schema_retriever', SchemaRetriever::class)
-      ->add('dkan_metastore.sae_factory', Sae::class)
-      ->add('plugin.manager.dkan_common.data_modifier', DataModifierManager::class);
+      ->add('dkan_metastore.sae_factory', Sae::class);
 
     return (new Chain($this))
       ->add(Container::class, "get", $options)
-      ->add(SchemaRetriever::class, "retrieve", json_encode("blah"))
-      ->add(DataModifierManager::class, 'getDefinitions', []);
+      ->add(SchemaRetriever::class, "retrieve", json_encode("blah"));
   }
 
 }

--- a/modules/custom/dkan_metastore/tests/src/Unit/WebServiceApiDocsTest.php
+++ b/modules/custom/dkan_metastore/tests/src/Unit/WebServiceApiDocsTest.php
@@ -2,6 +2,9 @@
 
 namespace Drupal\Tests\dkan_metastore\Unit;
 
+use Drupal\Core\Database\Query\SelectInterface;
+use Drupal\dkan_common\Plugin\DataModifierManager;
+use Drupal\dkan_common\Plugin\DataModifierBase;
 use PHPUnit\Framework\TestCase;
 use Drupal\Core\Serialization\Yaml;
 use Drupal\dkan_api\Controller\Docs;
@@ -17,15 +20,48 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class WebServiceApiDocsTest extends TestCase {
 
   /**
-   *
+   * Tests dataset-specific docs without data modifier plugin.
    */
-  public function testGetDatasetSpecific() {
-    $mockChain = $this->getCommonMockChain();
+  public function testDatasetSpecificDocsWithoutSqlModifier() {
+    $dataset = json_encode([
+      'distribution' => [
+      [
+        'identifier' => 'dist-1234',
+        'data' => [
+          'title' => 'Title',
+          'description' => 'Description',
+        ],
+      ],
+      ],
+    ]);
+
+    $mockChain = $this->getCommonMockChain()
+      ->add(Service::class, "get", $dataset)
+      ->add(DataModifierManager::class, 'getDefinitions', [])
+      ->add(SelectInterface::class, 'fetchCol', []);
 
     $controller = WebServiceApiDocs::create($mockChain->getMock());
     $response = $controller->getDatasetSpecific(1);
 
-    $spec = '{"openapi":"3.0.1","info":{"title":"API Documentation","version":"Alpha"},"tags":[{"name":"Dataset"},{"name":"SQL Query"}],"paths":{"\/api\/1\/datastore\/sql":{"get":{"summary":"Query resources","tags":["SQL Query"],"responses":{"200":{"description":"Ok"}}}},"\/api\/1\/metastore\/schemas\/dataset\/items\/1":{"get":{"summary":"Get this dataset","tags":["Dataset"],"responses":{"200":{"description":"Ok"}}}}}}';
+    $spec = '{"openapi":"3.0.1","info":{"title":"API Documentation","version":"Alpha"},"tags":[{"name":"Dataset"},{"name":"SQL Query"}],"paths":{"\/api\/1\/metastore\/schemas\/dataset\/items\/1":{"get":{"summary":"Get this dataset","tags":["Dataset"],"responses":{"200":{"description":"Ok"}}}},"\/api\/1\/datastore\/sql?query=[SELECT * FROM dist-1234];":{"get":{"summary":"Title","tags":["SQL Query"],"responses":{"200":{"description":"Ok"}},"description":"Description"}}}}';
+
+    $this->assertEquals($spec, $response->getContent());
+  }
+
+  /**
+   * Tests dataset-specific docs when SQL endpoint is protected.
+   */
+  public function testDatasetSpecificDocsWithSqlModifier() {
+    $mockChain = $this->getCommonMockChain()
+      ->add(Service::class, "get", "{}")
+      ->add(DataModifierManager::class, 'getDefinitions', [['id' => 'foobar']])
+      ->add(DataModifierManager::class, 'createInstance', DataModifierBase::class)
+      ->add(DataModifierBase::class, 'requiresModification', TRUE);
+
+    $controller = WebServiceApiDocs::create($mockChain->getMock());
+    $response = $controller->getDatasetSpecific(1);
+
+    $spec = '{"openapi":"3.0.1","info":{"title":"API Documentation","version":"Alpha"},"tags":[{"name":"Dataset"}],"paths":{"\/api\/1\/metastore\/schemas\/dataset\/items\/1":{"get":{"summary":"Get this dataset","tags":["Dataset"],"responses":{"200":{"description":"Ok"}}}}}}';
 
     $this->assertEquals($spec, $response->getContent());
   }
@@ -42,9 +78,10 @@ class WebServiceApiDocsTest extends TestCase {
     $mockChain->add(ContainerInterface::class, 'get',
       (new Options)->add('dkan_api.docs', Docs::class)
         ->add('dkan_metastore.service', Service::class)
+        ->add('plugin.manager.dkan_common.data_modifier', DataModifierManager::class)
     )
-      ->add(Docs::class, "getJsonFromYmlFile", $serializer->decode($yamlSpec))
-      ->add(Service::class, "get", "{}");
+      ->add(Docs::class, "getJsonFromYmlFile", $serializer->decode($yamlSpec));
+
     return $mockChain;
   }
 

--- a/modules/custom/dkan_non_public/dkan_non_public.info.yml
+++ b/modules/custom/dkan_non_public/dkan_non_public.info.yml
@@ -1,0 +1,7 @@
+name: 'Non Public Data Modifier'
+description: 'Protects the resources of datasets with non-public access level, on publicly accessible endpoints.'
+type: module
+core: 8.x
+package: DKAN
+dependencies:
+  - dkan_alt_api

--- a/modules/custom/dkan_non_public/src/Plugin/DataModifier/NonPublicResourceProtector.php
+++ b/modules/custom/dkan_non_public/src/Plugin/DataModifier/NonPublicResourceProtector.php
@@ -1,0 +1,297 @@
+<?php
+
+namespace Drupal\dkan_non_public\Plugin\DataModifier;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\dkan_common\Plugin\DataModifierBase;
+use Drupal\dkan_data\Service\Uuid5;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Implements a data modifier plugin to protect non-public datasets' resources.
+ *
+ * @DataModifier(
+ *   id = "non_public_resource_protector",
+ *   label = @Translation("Protects resources of non-public datasets"),
+ * )
+ */
+class NonPublicResourceProtector extends DataModifierBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * List of schemas to protect.
+   *
+   * @var array
+   */
+  private $schemasToModify = [
+    'dataset',
+    'distribution',
+  ];
+
+  /**
+   * The route matching service.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  private $routeMatch;
+
+  /**
+   * The database service.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  private $database;
+
+  /**
+   * The uuid5 service.
+   *
+   * @var \Drupal\dkan_data\Service\Uuid5
+   */
+  private $uuid5;
+
+  /**
+   * NonPublicResourceProtector constructor.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $routeMatch
+   *   The current route match service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, Connection $database, RouteMatchInterface $routeMatch, Uuid5 $uuid5) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->configuration = $configuration;
+    $this->pluginId = $plugin_id;
+    $this->pluginDefinition = $plugin_definition;
+    $this->database = $database;
+    $this->routeMatch = $routeMatch;
+    $this->uuid5 = $uuid5;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('database'),
+      $container->get('current_route_match'),
+      $container->get('dkan_data.uuid5')
+    );
+  }
+
+  /**
+   * Check if a resource needs to be protected.
+   *
+   * @param string $schema
+   *   The schema id.
+   * @param object|string $data
+   *   Object, json or identifier string representing a dataset or distribution.
+   *
+   * @return bool
+   *   TRUE if the data requires modification, FALSE otherwise.
+   */
+  public function requiresModification(string $schema, $data) {
+    return in_array($schema, $this->schemasToModify)
+      && !$this->alternateEndpoint()
+      && $this->accessLevel($schema, $data) === 'non-public';
+  }
+
+  /**
+   * Check if user requests one of the alternate dkan_alt_api endpoint.
+   *
+   * @return bool
+   *   TRUE from alternate endpoints, FALSE otherwise.
+   */
+  private function alternateEndpoint() {
+    $routeName = $this->routeMatch->getRouteName();
+    return strpos($routeName, 'dkan_alt_api.') ===0;
+  }
+
+  /**
+   * Check if a dataset or a distribution's parent has non-public access level.
+   *
+   * @param string $schema
+   *   The schema id.
+   * @param mixed $data
+   *   Object, json or identifier string representing a dataset or distribution.
+   *
+   * @return bool
+   *   TRUE if non-public, FALSE otherwise.
+   */
+  private function accessLevel(string $schema, $data) : string {
+    // For distributions, check their parent dataset's access level.
+    if ('distribution' === $schema) {
+      return $this->parentDatasetAccessLevel($data);
+    }
+    return $this->datasetAccessLevel($data);
+  }
+
+  /**
+   * Returns a dataset's access level.
+   *
+   * @param object|string $data
+   *   A dataset object or json string.
+   *
+   * @return string
+   *   The access level of the dataset.
+   */
+  private function datasetAccessLevel($data) {
+    if (is_string($data)) {
+      $data = json_decode($data);
+    }
+    return $data->accessLevel;
+  }
+
+  /**
+   * Get the access level of a distribution's parent dataset.
+   *
+   * @param object|string $dist
+   *   Object, json or identifier string representing a distribution.
+   *
+   * @return string
+   *   The parent dataset's access level.
+   */
+  private function parentDatasetAccessLevel($dist) {
+    $identifier = $this->getIdentifier($dist);
+    $parentDataset = $this->getParentDataset($identifier);
+    return $this->datasetAccessLevel($parentDataset);
+  }
+
+  /**
+   * Get a distribution's identifier, from its object or json string.
+   *
+   * @param object|string $dist
+   *   Object, json or identifier string representing a distribution.
+   *
+   * @return string
+   *   The distribution's identifier.
+   */
+  private function getIdentifier($dist) : string {
+    if (is_string($dist)) {
+      if ($this->uuid5->isValid($dist)) {
+        return $dist;
+      }
+      $dist = json_decode($dist);
+    }
+    return $dist->identifier;
+  }
+
+  /**
+   * Get the metadata of a distribution's parent dataset.
+   *
+   * @param string $identifier
+   *   The distribution's identifier.
+   *
+   * @return string|bool
+   *   The dataset's metadata, or FALSE.
+   */
+  private function getParentDataset($identifier) {
+    $datasets = $this->database->select('node__field_json_metadata', 'm')
+      ->condition('m.field_json_metadata_value', '%accessLevel%', 'LIKE')
+      ->condition('m.field_json_metadata_value', "%{$identifier}%", 'LIKE')
+      ->fields('m', ['field_json_metadata_value'])
+      ->execute()
+      ->fetchCol();
+
+    if ($dataset = reset($datasets)) {
+      return $dataset;
+    }
+    else {
+      return FALSE;
+    }
+  }
+
+  /**
+   * Protect potentially sensitive data in a dataset or distribution.
+   *
+   * @param string $schema
+   *   The schema id.
+   * @param object|string $data
+   *   Object, json or identifier string representing a dataset or distribution.
+   *
+   * @return mixed
+   *   Modified data, or FALSE.
+   */
+  public function modify(string $schema, $data) {
+    if ('distribution' === $schema) {
+      return $this->protectDistribution($data);
+    }
+    return $this->protectDataset($data);
+  }
+
+  /**
+   * Protect dataset object or string.
+   *
+   * @param object|string $dataset
+   *   A dataset object or json string.
+   *
+   * @return object|string
+   *   The protected dataset.
+   */
+  private function protectDataset($dataset) {
+    if (is_string($dataset)) {
+      $datasetObj = json_decode($dataset);
+      $datasetObj = $this->protectDatasetObject($datasetObj);
+      return json_encode($datasetObj);
+    }
+    return $this->protectDatasetObject($dataset);
+  }
+
+  /**
+   * Protect dataset object.
+   *
+   * @param object $dataset
+   *   The dataset object.
+   *
+   * @return object
+   *   The protected dataset object
+   */
+  private function protectDatasetObject($dataset) {
+    if (isset($dataset->distribution) && is_array($dataset->distribution)) {
+      foreach ($dataset->distribution as $key => &$dist) {
+        $dataset->distribution[$key] = $this->protectDistributionObject($dist);
+      }
+    }
+    return $dataset;
+  }
+
+  /**
+   * Protect distribution, both object and json strings.
+   *
+   * @param object|string $dist
+   *   A distribution object or json string.
+   *
+   * @return false|mixed|string
+   *   A protected distribution.
+   */
+  private function protectDistribution($dist) {
+    if (is_string($dist)) {
+      $distObj = json_decode($dist);
+      $distObj = $this->protectDistributionObject($distObj);
+      return json_encode($distObj);
+    }
+    return $this->protectDistributionObject($dist);
+  }
+
+  /**
+   * Protect distribution object.
+   *
+   * @param object $dist
+   *   A distribution object.
+   *
+   * @return object
+   *   A protected distribution object, with an explanation.
+   */
+  private function protectDistributionObject($dist) {
+    unset($dist);
+    return (object) ['title' => 'Resource hidden since dataset access level is non-public'];
+  }
+
+}

--- a/modules/custom/dkan_non_public/src/Plugin/DataModifier/NonPublicResourceProtector.php
+++ b/modules/custom/dkan_non_public/src/Plugin/DataModifier/NonPublicResourceProtector.php
@@ -206,12 +206,7 @@ class NonPublicResourceProtector extends DataModifierBase implements ContainerFa
       ->execute()
       ->fetchCol();
 
-    if ($dataset = reset($datasets)) {
-      return $dataset;
-    }
-    else {
-      return FALSE;
-    }
+    return reset($datasets);
   }
 
   /**

--- a/modules/custom/dkan_non_public/src/Plugin/DataModifier/NonPublicResourceProtector.php
+++ b/modules/custom/dkan_non_public/src/Plugin/DataModifier/NonPublicResourceProtector.php
@@ -15,6 +15,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @DataModifier(
  *   id = "non_public_resource_protector",
  *   label = @Translation("Protects resources of non-public datasets"),
+ *   result = @Translation("Resource hidden since dataset access level is non-public."),
+ *   code = "401",
  * )
  */
 class NonPublicResourceProtector extends DataModifierBase implements ContainerFactoryPluginInterface {
@@ -55,12 +57,16 @@ class NonPublicResourceProtector extends DataModifierBase implements ContainerFa
    *
    * @param array $configuration
    *   A configuration array containing information about the plugin instance.
-   * @param $plugin_id
+   * @param string $plugin_id
    *   The plugin_id for the plugin instance.
-   * @param $plugin_definition
+   * @param mixed $plugin_definition
    *   The plugin implementation definition.
+   * @param \Drupal\Core\Database\Connection $database
+   *   The database service.
    * @param \Drupal\Core\Routing\RouteMatchInterface $routeMatch
    *   The current route match service.
+   * @param \Drupal\dkan_data\Service\Uuid5 $uuid5
+   *   The uuid5 service.
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, Connection $database, RouteMatchInterface $routeMatch, Uuid5 $uuid5) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
@@ -111,7 +117,7 @@ class NonPublicResourceProtector extends DataModifierBase implements ContainerFa
    */
   private function alternateEndpoint() {
     $routeName = $this->routeMatch->getRouteName();
-    return strpos($routeName, 'dkan_alt_api.') ===0;
+    return strpos($routeName, 'dkan_alt_api.') === 0;
   }
 
   /**
@@ -291,7 +297,7 @@ class NonPublicResourceProtector extends DataModifierBase implements ContainerFa
    */
   private function protectDistributionObject($dist) {
     unset($dist);
-    return (object) ['title' => 'Resource hidden since dataset access level is non-public'];
+    return (object) ['title' => $this->message()];
   }
 
 }

--- a/modules/custom/dkan_non_public/tests/src/Unit/Plugin/DataModifier/NonPublicResourceProtectorTest.php
+++ b/modules/custom/dkan_non_public/tests/src/Unit/Plugin/DataModifier/NonPublicResourceProtectorTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Drupal\Tests\dkan_non_public\Unit;
+
+use Drupal\Core\Annotation\Translation;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Database\Query\ConditionInterface;
+use Drupal\Core\Database\Query\SelectInterface;
+use Drupal\Core\Database\StatementInterface;
+use Drupal\Core\DependencyInjection\Container;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\dkan_common\Plugin\DataModifierBase;
+use Drupal\dkan_common\Plugin\DataModifierInterface;
+use Drupal\dkan_data\Service\Uuid5;
+use Drupal\dkan_non_public\Plugin\DataModifier\NonPublicResourceProtector;
+use MockChain\Chain;
+use MockChain\Options;
+use PHPUnit\Framework\TestCase;
+
+class NonPublicResourceProtectorTest extends TestCase {
+
+  public function testConstructor() {
+    $plugin = NonPublicResourceProtector::create(
+      $this->getCommonMockChain()->getMock(),
+      [],
+      'non_public_resource_protector',
+      []
+    );
+
+    $this->assertTrue(is_object($plugin));
+  }
+
+  public function requiresModificationProvider() {
+    // Schema
+    // Data object, json string or uuid
+    // Dataset returned from searching
+    // Expected return boolean
+
+    return [
+      'public dataset object' => [
+        'dataset',
+        (object) ['accessLevel' => 'public'],
+        [],
+        FALSE,
+      ],
+      'resource object with non-public parent dataset' => [
+        'distribution',
+        (object) ['identifier' => '1', 'data' => ['foo' => 'bar']],
+        ['{"accessLevel":"non-public"}'],
+        TRUE,
+      ],
+      'resource json string with public parent dataset' => [
+        'distribution',
+        '{"identifier":"1","data":{"foo":"bar"}}',
+        ['{"accessLevel":"public"}'],
+        FALSE,
+      ],
+      'resource uuid with public parent dataset' => [
+        'distribution',
+        '6b1f0bb4-60cd-5b27-8e03-5fecff4c7e2a',
+        ['{"accessLevel":"non-public"}'],
+        TRUE,
+      ],
+    ];
+  }
+
+  /**
+   * @dataProvider requiresModificationProvider
+   */
+  public function testRequiresModification(string $schema, $data, $datasets, $expected) {
+    $container = $this->getCommonMockChain()
+      ->add(StatementInterface::class, 'fetchCol', $datasets);
+
+    $plugin = NonPublicResourceProtector::create(
+      $container->getMock(),
+      [],
+      'non_public_resource_protector',
+      []
+    );
+
+    $this->assertEquals($expected, $plugin->requiresModification($schema, $data));
+  }
+
+  public function getCommonMockChain() {
+    $options = (new Options())
+      ->add('database', Connection::class)
+      ->add('current_route_match', RouteMatchInterface::class)
+      ->add('dkan_data.uuid5', Uuid5::class);
+
+    return (new Chain($this))
+      ->add(Container::class, 'get', $options)
+      ->add(Connection::class, 'select', SelectInterface::class)
+      ->add(SelectInterface::class, 'condition', ConditionInterface::class)
+      ->add(ConditionInterface::class, 'condition', ConditionInterface::class)
+      ->add(ConditionInterface::class, 'fields', SelectInterface::class)
+      ->add(SelectInterface::class, 'execute', StatementInterface::class)
+      ->add(StatementInterface::class, 'fetchCol', []);
+  }
+
+}

--- a/modules/custom/dkan_sql_endpoint/src/Controller/Api.php
+++ b/modules/custom/dkan_sql_endpoint/src/Controller/Api.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\dkan_sql_endpoint\Controller;
 
+use Drupal\dkan_common\DataModifierPluginTrait;
+use Drupal\dkan_common\Plugin\DataModifierManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Drupal\Core\Database\Connection;
@@ -17,6 +19,7 @@ use Drupal\dkan_sql_endpoint\Service;
  */
 class Api implements ContainerInjectionInterface {
   use JsonResponseTrait;
+  use DataModifierPluginTrait;
 
   private $service;
   private $database;
@@ -37,7 +40,8 @@ class Api implements ContainerInjectionInterface {
       $container->get('database'),
       $container->get('dkan_datastore.service.factory.resource'),
       $container->get('request_stack'),
-      $container->get('dkan_datastore.database_table_factory')
+      $container->get('dkan_datastore.database_table_factory'),
+      $container->get('plugin.manager.dkan_common.data_modifier')
     );
   }
 
@@ -49,13 +53,17 @@ class Api implements ContainerInjectionInterface {
     Connection $database,
     Resource $resourceServiceFactory,
     RequestStack $requestStack,
-    DatabaseTableFactory $databaseTableFactory
+    DatabaseTableFactory $databaseTableFactory,
+    DataModifierManager $pluginManager
   ) {
     $this->service = $service;
     $this->database = $database;
     $this->resourceServiceFactory = $resourceServiceFactory;
     $this->requestStack = $requestStack;
     $this->databaseTableFactory = $databaseTableFactory;
+    $this->pluginManager = $pluginManager;
+
+    $this->plugins = $this->discoverDataModifierPlugins();
   }
 
   /**
@@ -103,7 +111,12 @@ class Api implements ContainerInjectionInterface {
       return $this->getResponseFromException($e);
     }
 
-    $databaseTable = $this->getDatabaseTable($this->service->getTableName($query));
+    $uuid = $this->service->getTableName($query);
+    $modify = $this->modifyData($uuid);
+    if ($modify) {
+      return $this->getResponse((object) ["message" => "Resource hidden since dataset access level is non-public"], 401);
+    }
+    $databaseTable = $this->getDatabaseTable($uuid);
 
     try {
       $result = $databaseTable->query($queryObject);
@@ -113,6 +126,24 @@ class Api implements ContainerInjectionInterface {
     }
 
     return $this->getResponse($result, 200);
+  }
+
+  /**
+   * Provides data modifiers plugins an opportunity to act.
+   *
+   * @param string $identifier
+   *   The distribution's identifier.
+   *
+   * @return bool
+   *   TRUE if sql endpoint docs needs to be protected, FALSE otherwise.
+   */
+  private function modifyData(string $identifier) {
+    foreach ($this->plugins as $plugin) {
+      if ($plugin->requiresModification('distribution', $identifier)) {
+        return TRUE;
+      }
+    }
+    return FALSE;
   }
 
   /**

--- a/modules/custom/dkan_sql_endpoint/src/Controller/Api.php
+++ b/modules/custom/dkan_sql_endpoint/src/Controller/Api.php
@@ -63,7 +63,7 @@ class Api implements ContainerInjectionInterface {
     $this->databaseTableFactory = $databaseTableFactory;
     $this->pluginManager = $pluginManager;
 
-    $this->plugins = $this->discoverDataModifierPlugins();
+    $this->plugins = $this->discover();
   }
 
   /**

--- a/modules/custom/dkan_sql_endpoint/tests/src/Unit/Controller/ApiTest.php
+++ b/modules/custom/dkan_sql_endpoint/tests/src/Unit/Controller/ApiTest.php
@@ -8,6 +8,8 @@ use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\DependencyInjection\Container;
+use Drupal\dkan_common\Plugin\DataModifierBase;
+use Drupal\dkan_common\Plugin\DataModifierManager;
 use MockChain\Chain;
 use MockChain\Options;
 use Drupal\dkan_datastore\Storage\DatabaseTable;
@@ -30,7 +32,7 @@ class ApiTest extends TestCase {
    *
    */
   public function test() {
-    $controller = Api::create($this->getContainer());
+    $controller = Api::create($this->getCommonMockChain()->getMock());
     $response = $controller->runQueryGet();
     $this->assertEquals("[]", $response->getContent());
   }
@@ -39,7 +41,7 @@ class ApiTest extends TestCase {
    *
    */
   public function test2() {
-    $controller = Api::create($this->getContainer());
+    $controller = Api::create($this->getCommonMockChain()->getMock());
     $response = $controller->runQueryPost();
     $this->assertEquals("[]", $response->getContent());
   }
@@ -47,7 +49,22 @@ class ApiTest extends TestCase {
   /**
    *
    */
-  private function getContainer() {
+  public function testWithDataModifierPlugin() {
+    $container = $this->getCommonMockChain()
+      ->add(DataModifierManager::class, 'getDefinitions', [['id' => 'foobar']])
+      ->add(DataModifierManager::class, 'createInstance', DataModifierBase::class)
+      ->add(DataModifierBase::class, 'requiresModification', TRUE);
+
+    $controller = Api::create($container->getMock());
+    $response = $controller->runQueryGet();
+    $expected = '{"message":"Resource hidden since dataset access level is non-public"}';
+    $this->assertEquals($expected, $response->getContent());
+  }
+
+  /**
+   * @return \MockChain\Chain
+   */
+  public function getCommonMockChain() {
     $container = (new Chain($this))
       ->add(Container::class, "get", ConfigFactory::class)
       ->add(ConfigFactory::class, "get", ImmutableConfig::class)
@@ -59,12 +76,13 @@ class ApiTest extends TestCase {
       ->add("database", Connection::class)
       ->add('dkan_datastore.service.factory.resource', ResourceServiceFactory::class)
       ->add('request_stack', RequestStack::class)
-      ->add('dkan_datastore.database_table_factory', DatabaseTableFactory::class);
+      ->add('dkan_datastore.database_table_factory', DatabaseTableFactory::class)
+      ->add('plugin.manager.dkan_common.data_modifier', DataModifierManager::class);
 
     $query = '[SELECT * FROM abc][WHERE abc = \'blah\'][ORDER BY abc DESC][LIMIT 1 OFFSET 3];';
     $body = json_encode(["query" => $query]);
 
-    $container = (new Chain($this))
+    return (new Chain($this))
       ->add(Container::class, "get", $options)
       ->add(RequestStack::class, 'getCurrentRequest', Request::class)
       ->add(Request::class, 'get', $query)
@@ -76,9 +94,9 @@ class ApiTest extends TestCase {
       ->add(Resource::class, 'getId', "1")
       ->add(DatabaseTableFactory::class, 'getInstance', DatabaseTable::class)
       ->add(DatabaseTable::class, 'query', [])
-      ->getMock();
-
-    return $container;
+      ->add(DataModifierManager::class, 'getDefinitions', [])
+      ->add(DataModifierManager::class, 'createInstance', DataModifierBase::class)
+      ->add(DataModifierBase::class, 'requiresModification', FALSE);
   }
 
 }

--- a/modules/custom/dkan_sql_endpoint/tests/src/Unit/Controller/ApiTest.php
+++ b/modules/custom/dkan_sql_endpoint/tests/src/Unit/Controller/ApiTest.php
@@ -50,14 +50,19 @@ class ApiTest extends TestCase {
    *
    */
   public function testWithDataModifierPlugin() {
+    $pluginMessage = "Resource hidden since dataset access level is non-public.";
+    $pluginCode = 401;
+
     $container = $this->getCommonMockChain()
       ->add(DataModifierManager::class, 'getDefinitions', [['id' => 'foobar']])
       ->add(DataModifierManager::class, 'createInstance', DataModifierBase::class)
-      ->add(DataModifierBase::class, 'requiresModification', TRUE);
+      ->add(DataModifierBase::class, 'requiresModification', TRUE)
+      ->add(DataModifierBase::class, 'message', $pluginMessage)
+      ->add(DataModifierBase::class, 'httpCode', $pluginCode);
 
     $controller = Api::create($container->getMock());
     $response = $controller->runQueryGet();
-    $expected = '{"message":"Resource hidden since dataset access level is non-public"}';
+    $expected = '{"message":"Resource hidden since dataset access level is non-public."}';
     $this->assertEquals($expected, $response->getContent());
   }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,6 +16,7 @@
             <directory>modules/custom/dkan_frontend/tests/src/Unit</directory>
             <directory>modules/custom/dkan_harvest/test/src/Unit</directory>
             <directory>modules/custom/dkan_metastore/tests/src/Unit</directory>
+            <directory>modules/custom/dkan_non_public/tests/src/Unit</directory>
             <directory>modules/custom/dkan_schema/tests/src/Unit</directory>
             <directory>modules/custom/dkan_sql_endpoint/tests/src/Unit</directory>
         </testsuite>
@@ -44,6 +45,7 @@
             <directory>modules/custom/dkan_harvest/src</directory>
             <directory>modules/custom/dkan_lunr/src</directory>
             <directory>modules/custom/dkan_metastore/src</directory>
+            <directory>modules/custom/dkan_non_public/src</directory>
             <directory>modules/custom/dkan_schema/src</directory>
             <directory>modules/custom/dkan_sql_endpoint/src</directory>
       <!-- By definition test classes have no tests. -->


### PR DESCRIPTION
* Add a data modifier annotation-type plugin
* Potentially modifies output of publicly accessible endpoints in metastore schemas, datastore sql query and dataset-specific api docs
* Add a dkan_alt_api module, disabled by default
* Add a dkan_non_public module, disabled by default, implementing a data modifier plugin to protect resources of non-public datasets