### PR TITLE
Not all views display entities

### DIFF
--- a/modules/custom/dkan_admin/dkan_admin.module
+++ b/modules/custom/dkan_admin/dkan_admin.module
@@ -35,16 +35,17 @@ function dkan_admin_form_views_exposed_form_alter(&$form, FormStateInterface $fo
  * Implements template_preprocess_views_view_fields().
  */
 function dkan_admin_preprocess_views_view_field(&$vars) {
-  // To access current row entity.
-  $entity = $vars['row']->_entity;
-  $entity_id = $entity->id();
-  $uuid = $entity->uuid->value;
-
-  // To access entities from relationship.
-  // $entities = $vars['row']->_relationship_entities;.
   if (isset($vars['view'])
     && ($vars['view']->id() == 'dkan_content')
     && ($vars['view']->current_display == 'page_1')) {
+
+    // To access current row entity.
+    $entity = $vars['row']->_entity;
+    $entity_id = $entity->id();
+    $uuid = $entity->uuid->value;
+
+    // To access entities from relationship.
+    // $entities = $vars['row']->_relationship_entities;.
 
     if (isset($vars['view']->field) && (count($vars['view']->field) > 0)) {
       if ($vars['field']->field == 'nothing' && $entity->field_data_type->value == 'dataset') {


### PR DESCRIPTION
Visiting the Recent logs messages view caused the following error:

`Error: Call to a member function id() on null in dkan_admin_preprocess_views_view_field() (line 40 of /var/www/docroot/profiles/contrib/dkan2/modules/custom/dkan_admin/dkan_admin.module)`

Which I tracked it down to code which this PR moves into the conditional.