### PR TITLE
Add additional field options for indexing

### DIFF
--- a/modules/custom/dkan_search/src/ComplexData/Dataset.php
+++ b/modules/custom/dkan_search/src/ComplexData/Dataset.php
@@ -133,7 +133,8 @@ class Dataset extends ComplexDataFacade {
       && isset($this->data->{$matches[1]}->{$matches[2]})) {
         $value = $this->data->{$matches[1]}->{$matches[2]};
       }
-    } elseif (isset($this->data->{$property_name})) {
+    }
+    elseif (isset($this->data->{$property_name})) {
       $value = $this->data->{$property_name};
     }
 
@@ -151,7 +152,8 @@ class Dataset extends ComplexDataFacade {
           $values[] = $dist->{$matches[2]};
         }
       }
-    } else {
+    }
+    else {
       if (isset($this->data->{$property_name})) {
         $values = $this->data->{$property_name};
         if (is_string($values)) {

--- a/modules/custom/dkan_search/src/ComplexData/Dataset.php
+++ b/modules/custom/dkan_search/src/ComplexData/Dataset.php
@@ -34,7 +34,7 @@ class Dataset extends ComplexDataFacade {
           $definitions[$property . "__item__" . $child] = self::getDefinition($type);
         }
       }
-      else if ($type == "object" && isset($object->properties->{$property}->properties)) {
+      elseif ($type == "object" && isset($object->properties->{$property}->properties)) {
         $child_properties = array_keys((array) $object->properties->{$property}->properties);
         foreach ($child_properties as $child) {
           $child_type = $object->properties->{$property}->properties->{$child}->type;

--- a/modules/custom/dkan_search/src/ComplexData/Dataset.php
+++ b/modules/custom/dkan_search/src/ComplexData/Dataset.php
@@ -34,9 +34,9 @@ class Dataset extends ComplexDataFacade {
           $definitions[$property . "__item__" . $child] = self::getDefinition($type);
         }
       }
-      if ($type == "object" && isset($object->properties->{$property}->properties)) {
+      else if ($type == "object" && isset($object->properties->{$property}->properties)) {
         $child_properties = array_keys((array) $object->properties->{$property}->properties);
-        foreach($child_properties as $child) {
+        foreach ($child_properties as $child) {
           $child_type = $object->properties->{$property}->properties->{$child}->type;
           if ($child_type == 'string') {
             $definitions[$property . "__" . $child] = self::getDefinition($child_type);

--- a/modules/custom/dkan_search/src/ComplexData/Dataset.php
+++ b/modules/custom/dkan_search/src/ComplexData/Dataset.php
@@ -27,12 +27,23 @@ class Dataset extends ComplexDataFacade {
     $properties = array_keys((array) $object->properties);
 
     foreach ($properties as $property) {
-      if (isset($object->properties->{$property}->type)) {
-        $type = $object->properties->{$property}->type;
+      $type = $object->properties->{$property}->type;
+      if ($type == "object" && isset($object->properties->{$property}->properties)) {
+        $child_properties = array_keys((array) $object->properties->{$property}->properties);
+        foreach($child_properties as $child) {
+          $child_type = $object->properties->{$property}->properties->{$child}->type;
+          if ($child_type == 'string') {
+            $definitions[$property . ":" . $child] = self::getDefinition($child_type);
+            //var_dump($definitions[$property . ":" . $child]);
+          }
+        }
+      }
+      else {
         $definitions[$property] = self::getDefinition($type);
+        //var_dump($definitions[$property]);
       }
     }
-
+    
     return $definitions;
   }
 
@@ -47,7 +58,6 @@ class Dataset extends ComplexDataFacade {
     if ($type == "array") {
       return ListDataDefinition::create("string");
     }
-
     return DataDefinition::createFromDataType($type);
   }
 
@@ -64,6 +74,7 @@ class Dataset extends ComplexDataFacade {
    * @inheritDoc
    */
   public function get($property_name) {
+    exit(var_dump($property_name));
     $definitions = self::definition();
 
     if (!isset($definitions[$property_name])) {
@@ -94,6 +105,7 @@ class Dataset extends ComplexDataFacade {
    * @inheritDoc
    */
   public function getProperties($include_computed = FALSE) {
+    exit(var_dump($include_computed));
     $definitions = self::definition();
     $properties = [];
     foreach (array_keys($definitions) as $propertyName) {

--- a/modules/custom/dkan_search/src/ComplexData/Dataset.php
+++ b/modules/custom/dkan_search/src/ComplexData/Dataset.php
@@ -43,7 +43,8 @@ class Dataset extends ComplexDataFacade {
     if (($type == "array" && isset($object->properties->{$property_name}->items->properties))
     || $type == "object") {
       $defs = self::getComplexPropertyDefinition($object->properties->{$property_name}, $type, $property_name);
-    } else {
+    }
+    else {
       $defs[$property_name] = self::getDefinitionObject($type);
     }
     return $defs;

--- a/modules/custom/dkan_search/src/ComplexData/Dataset.php
+++ b/modules/custom/dkan_search/src/ComplexData/Dataset.php
@@ -146,20 +146,15 @@ class Dataset extends ComplexDataFacade {
    */
   private function getArrayValues($property_name) {
     $values = [];
-    if (preg_match('/(.*)__item__(.*)/', $property_name, $matches)) {
-      foreach ($this->data->{$matches[1]} as $dist) {
-        if (isset($dist->{$matches[2]})) {
-          $values[] = $dist->{$matches[2]};
-        }
+    $matches = [];
+    if (preg_match('/(.*)__item__(.*)/', $property_name, $matches)) {1
+      foreach ($this->data->{$matches[1]} as $dist) {1+1
+        $values[] = isset($dis->{$matches[2]}) ? $dist->{$matches[2]} : [];
       }
     }
-    else {
-      if (isset($this->data->{$property_name})) {
-        $values = $this->data->{$property_name};
-        if (is_string($values)) {
-          $values = json_decode($values);
-        }
-      }
+    elseif (isset($this->data->{$property_name})) {1
+      $values = $this->data->{$property_name};
+      $values = is_string($values) ? json_decode($values) : $values;
     }
 
     return $values;

--- a/modules/custom/dkan_search/src/ComplexData/Dataset.php
+++ b/modules/custom/dkan_search/src/ComplexData/Dataset.php
@@ -147,12 +147,12 @@ class Dataset extends ComplexDataFacade {
   private function getArrayValues($property_name) {
     $values = [];
     $matches = [];
-    if (preg_match('/(.*)__item__(.*)/', $property_name, $matches)) {1
-      foreach ($this->data->{$matches[1]} as $dist) {1+1
-        $values[] = isset($dis->{$matches[2]}) ? $dist->{$matches[2]} : [];
+    if (preg_match('/(.*)__item__(.*)/', $property_name, $matches)) {
+      foreach ($this->data->{$matches[1]} as $dist) {
+        $values[] = isset($dist->{$matches[2]}) ? $dist->{$matches[2]} : [];
       }
     }
-    elseif (isset($this->data->{$property_name})) {1
+    elseif (isset($this->data->{$property_name})) {
       $values = $this->data->{$property_name};
       $values = is_string($values) ? json_decode($values) : $values;
     }

--- a/modules/custom/dkan_search/src/ComplexData/Dataset.php
+++ b/modules/custom/dkan_search/src/ComplexData/Dataset.php
@@ -29,8 +29,8 @@ class Dataset extends ComplexDataFacade {
     foreach ($properties as $property) {
       $defs = [];
       $type = $object->properties->{$property}->type;
-      if (($type == "array" && isset($object->properties->{$property}->items->properties))
-        || $type == "object") {
+      $array_has_items = ($type == "array" && isset($object->properties->{$property}->items->properties));
+      if ($array_has_items || $type == "object") {
         $defs = self::definitionHelper($object->properties->{$property}, $type, $property);
       }
       else {
@@ -60,7 +60,7 @@ class Dataset extends ComplexDataFacade {
       $child_properties = array_keys((array) $props);
     }
     else {
-      $defs[$property_name] = self::getDefinition($type);
+      $definitions[$property_name] = self::getDefinition($type);
     }
 
     foreach ($child_properties as $child) {

--- a/modules/custom/dkan_search/src/WebServiceApi.php
+++ b/modules/custom/dkan_search/src/WebServiceApi.php
@@ -178,6 +178,7 @@ class WebServiceApi {
    */
   private function getFacetsForType(QueryInterface $query, $type) {
     $facets = [];
+    $field = '';
 
     /* @var  $metastore Service */
     $metastore = \Drupal::service("dkan_metastore.service");
@@ -187,15 +188,13 @@ class WebServiceApi {
     if (preg_match('/(.*)__(.*)/', $type, $matches)) {
       $schema = $matches[1];
       $field = $matches[2];
-
-      foreach ($metastore->getAll($schema) as $thing) {
-        $facets[] = $this->getFacetHelper($query, $type, $thing->data->{$field});
-      }
     }
     else {
-      foreach ($metastore->getAll($type) as $thing) {
-        $facets[] = $this->getFacetHelper($query, $type, $thing->data);
-      }
+      $schema = $type;
+    }
+    foreach ($metastore->getAll($schema) as $thing) {
+      $facet_name = empty($field) ? $thing->data : $thing->data->{$field};
+      $facets[] = $this->getFacetHelper($query, $type, $facet_name);
     }
 
     return $facets;

--- a/modules/custom/dkan_search/src/WebServiceApi.php
+++ b/modules/custom/dkan_search/src/WebServiceApi.php
@@ -189,30 +189,30 @@ class WebServiceApi {
       $field = $matches[2];
 
       foreach ($metastore->getAll($schema) as $thing) {
-        $myquery = clone $query;
-        $myquery->addCondition($type, $thing->data->{$field});
-        $result = $myquery->execute();
-        $facets[] = [
-          'type' => $type,
-          'name' => $thing->data->{$field},
-          'total' => $result->getResultCount(),
-        ];
+        $facets[] = $this->getFacetHelper($query, $type, $thing->data->{$field});
       }
     }
     else {
       foreach ($metastore->getAll($type) as $thing) {
-        $myquery = clone $query;
-        $myquery->addCondition($type, $thing->data);
-        $result = $myquery->execute();
-        $facets[] = [
-          'type' => $type,
-          'name' => $thing->data,
-          'total' => $result->getResultCount(),
-        ];
+        $facets[] = $this->getFacetHelper($query, $type, $thing->data);
       }
     }
 
     return $facets;
+  }
+
+  /**
+   * Private.
+   */
+  private function getFacetHelper(QueryInterface $query, $type, $facet_name) {
+    $myquery = clone $query;
+    $myquery->addCondition($type, $facet_name);
+    $result = $myquery->execute();
+    return [
+      'type' => $type,
+      'name' => $facet_name,
+      'total' => $result->getResultCount(),
+    ];
   }
 
   /**

--- a/modules/custom/dkan_search/tests/src/Unit/ComplexData/DatasetTest.php
+++ b/modules/custom/dkan_search/tests/src/Unit/ComplexData/DatasetTest.php
@@ -26,11 +26,11 @@ class DatasetTest extends TestCase {
       "properties": {
         "firstName": {
           "type": "string",
-          "description": "The person\'s first name."
+          "description": "First name."
         },
         "lastName": {
           "type": "string",
-          "description": "The person\'s last name."
+          "description": "Last name."
         },
         "occupations" : {
           "type": "array"
@@ -39,6 +39,20 @@ class DatasetTest extends TestCase {
           "description": "Age in years which must be equal to or greater than zero.",
           "type": "integer",
           "minimum": 0
+        },
+        "address": {
+          "type": "object",
+          "properties": {
+            "city": {
+              "coords": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "state": {
+              "type": "string"
+            }
+          }
         }
       }
     }
@@ -62,7 +76,7 @@ class DatasetTest extends TestCase {
     $this->assertEquals($json, json_encode($dataset->getValue()));
 
     $properties = $dataset->getProperties();
-    $this->assertEquals(4, count($properties));
+    $this->assertEquals(6, count($properties));
   }
 
 }

--- a/modules/custom/dkan_search/tests/src/Unit/WebServiceApi2Test.php
+++ b/modules/custom/dkan_search/tests/src/Unit/WebServiceApi2Test.php
@@ -59,13 +59,15 @@ class WebServiceApi2Test extends TestCase {
       ->add(Item::class, 'getId', 1)
       ->getMock();
 
-    $thing = (object) ['title' => 'hello', 'description' => 'goodbye'];
+    $thing = (object) ['title' => 'hello', 'description' => 'goodbye', 'publisher__name' => 'Steve'];
+    $facet = (object) ['data' => (object) ['name' => 'Steve']];
+    $expect = (object) ['type' => 'publisher__name', 'name' => 'Steve', 'total' => 1];
 
     $container = (new Chain($this))
       ->add(Container::class, "get", $options)
       ->add(EntityManager::class, 'getStorage', EntityStorageInterface::class)
       ->add(EntityStorageInterface::class, 'load', IndexInterface::class)
-      ->add(IndexInterface::class, 'getFields', ['description' => 'blah'])
+      ->add(IndexInterface::class, 'getFields', ['description' => 'blah', 'publisher__name' => 'blah'])
       ->add(IndexInterface::class, 'getFulltextFields', ['title'])
       ->add(RequestStack::class, 'getCurrentRequest', $request)
       ->add(QueryHelperInterface::class, 'createQuery', QueryInterface::class)
@@ -74,6 +76,7 @@ class WebServiceApi2Test extends TestCase {
       ->add(ResultSet::class, 'getResultCount', 1)
       ->add(ResultSet::class, 'getResultItems', [$item])
       ->add(Service::class, 'get', json_encode($thing))
+      ->add(Service::class, 'getAll', [$facet])
       ->getMock();
 
     \Drupal::setContainer($container);
@@ -83,7 +86,7 @@ class WebServiceApi2Test extends TestCase {
     /* @var $response \Symfony\Component\HttpFoundation\JsonResponse */
     $response = $controller->search();
     $this->assertEquals(
-      json_encode((object) ['total' => 1, 'results' => [$thing], 'facets' => []]),
+      json_encode((object) ['total' => 1, 'results' => [$thing], 'facets' => [$expect]]),
       $response->getContent());
   }
 

--- a/schema/collections/dataset.json
+++ b/schema/collections/dataset.json
@@ -135,7 +135,49 @@
       "description": "Most recent date on which the dataset was changed, updated or modified.",
       "type": "string"
     },
-    "publisher": {"$ref": "#/definitions/organization"},
+    "publisher": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "id": "https://project-open-data.cio.gov/v1.1/schema/organization.json#",
+      "title": "Organization",
+      "description": "A Dataset Publisher Organization.",
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "@type": {
+          "title": "Metadata Context",
+          "description": "IRI for the JSON-LD data type. This should be org:Organization for each publisher",
+          "type": "string",
+          "default": "org:Organization"
+        },
+        "name": {
+          "title": "Publisher Name",
+          "description": "A full formatted name, eg Firstname Lastname",
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "title": "Description",
+          "type": "string",
+          "description": "Description of the organization"
+        },
+        "identifier": {
+          "type": "string",
+          "title": "Identifier"
+        },
+        "image": {
+          "title": "Image",
+          "description": "Image or logo for the organization",
+          "type": "string",
+          "format": "uri"
+        },
+        "subOrganizationOf": {
+          "title": "Parent Organization",
+          "type": "string"
+        }
+      }
+    },
     "references": {
       "title": "Related Documents",
       "description": "Related documents such as technical information about a dataset, developer documentation, etc.",
@@ -309,49 +351,6 @@
               }
             }
           }
-        }
-      }
-    },
-    "organization": {
-      "$schema": "http://json-schema.org/draft-04/schema#",
-      "id": "https://project-open-data.cio.gov/v1.1/schema/organization.json#",
-      "title": "Organization",
-      "description": "A Dataset Publisher Organization.",
-      "type": "object",
-      "required": [
-        "name"
-      ],
-      "properties": {
-        "@type": {
-          "title": "Metadata Context",
-          "description": "IRI for the JSON-LD data type. This should be org:Organization for each publisher",
-          "type": "string",
-          "default": "org:Organization"
-        },
-        "name": {
-          "title": "Publisher Name",
-          "description": "A full formatted name, eg Firstname Lastname",
-          "type": "string",
-          "minLength": 1
-        },
-        "description": {
-          "title": "Description",
-          "type": "string",
-          "description": "Description of the organization"
-        },
-        "identifier": {
-          "type": "string",
-          "title": "Identifier"
-        },
-        "image": {
-          "title": "Image",
-          "description": "Image or logo for the organization",
-          "type": "string",
-          "format": "uri"
-        },
-        "subOrganizationOf": {
-          "title": "Parent Organization",
-          "type": "string"
         }
       }
     }

--- a/schema/collections/dataset.json
+++ b/schema/collections/dataset.json
@@ -93,7 +93,152 @@
       "description": "A container for the array of Distribution objects",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/distribution",
+        "title": "Project Open Data Distribution",
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "properties": {
+          "@type": {
+            "title": "Metadata Context",
+            "description": "IRI for the JSON-LD data type. This should be dcat:Distribution for each Distribution",
+            "default": "dcat:Distribution",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "description": "Human-readable name of the distribution",
+            "type": "string",
+            "minLength": 1
+          },
+          "identifier": {
+            "title": "Identifier",
+            "description": "Distribution identifier",
+            "type": "string"
+          },
+          "description": {
+            "title": "Description",
+            "description": "Human-readable description of the distribution",
+            "type": "string",
+            "minLength": 1
+          },
+          "fileLocation": {
+            "title": " ",
+            "type": "string"
+          },
+          "format": {
+            "title": "Format",
+            "description": "A human-readable description of the file format of a distribution",
+            "type": "string"
+          },
+          "mediaType": {
+            "title": "Media Type",
+            "description": "The machine-readable file format (IANA Media Type or MIME Type) of the distribution’s downloadURL",
+            "type": "string"
+          },
+          "mediaSize": {
+            "title": "Media Size",
+            "description": "The size of the meida file.",
+            "type": "integer"
+          },
+          "downloadURL": {
+            "title": "Download URL",
+            "description": "URL providing direct access to a downloadable file of a dataset",
+            "type": "string",
+            "format": "uri"
+          },
+          "accessURL": {
+            "title": "Access URL",
+            "description": "URL providing indirect access to a dataset",
+            "type": "string",
+            "format": "uri"
+          },
+          "conformsTo": {
+            "title": "Data Standard",
+            "description": "URL providing indirect access to a dataset",
+            "type": "string",
+            "format": "uri"
+          },
+          "describedBy": {
+            "title": "Data Dictionary",
+            "description": "URL to the data dictionary for the distribution found at the downloadURL",
+            "type": "string",
+            "format": "uri"
+          },
+          "describedByType": {
+            "title": "Data Dictionary Type",
+            "description": "The machine-readable file format (IANA Media Type or MIME Type) of the distribution’s describedBy URL",
+            "pattern": "^[a-z]+?$",
+            "type": "string"
+          },
+          "issued": {
+            "title": "Release Date",
+            "description": "Date of formal issuance.",
+            "type": "string",
+            "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+          },
+          "schema": {
+            "title": "Schema",
+            "description": "Ref of https://frictionlessdata.io/schemas/table-schema.json",
+            "type": "object",
+            "properties": {
+              "fields": {
+                "type": "array",
+                "items": {
+                  "title": "Table Schema Field",
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "title": "Name",
+                      "description": "A name for this field.",
+                      "type": "string"
+                    },
+                    "title": {
+                      "title": "Title",
+                      "description": "A human-readable title.",
+                      "type": "string"
+                    },
+                    "description": {
+                      "title": "Description",
+                      "description": "A text description. Markdown is encouraged.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "The type for the data.",
+                      "type": "string",
+                      "enum": [
+                        "string",
+                        "integer",
+                        "number",
+                        "boolean",
+                        "object",
+                        "array",
+                        "date",
+                        "time",
+                        "datetime",
+                        "year",
+                        "yearmonth",
+                        "duration",
+                        "geopoint",
+                        "geojson"
+                      ]
+                    },
+                    "format": {
+                      "description": "The format keyword options for `string` are `default`, `email`, `uri`, `binary`, and `uuid`.",
+                      "enum": [
+                        "default",
+                        "email",
+                        "uri",
+                        "binary",
+                        "uuid"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "minItems": 1,
         "uniqueItems": true
       }
@@ -203,156 +348,6 @@
       "description": "The collection of which the dataset is a subset",
       "type": "string",
       "minLength": 1
-    }
-  },
-  "definitions": {
-    "distribution": {
-      "title": "Project Open Data Distribution",
-      "type": "object",
-      "required": [
-        "title"
-      ],
-      "properties": {
-        "@type": {
-          "title": "Metadata Context",
-          "description": "IRI for the JSON-LD data type. This should be dcat:Distribution for each Distribution",
-          "default": "dcat:Distribution",
-          "type": "string"
-        },
-        "title": {
-          "title": "Title",
-          "description": "Human-readable name of the distribution",
-          "type": "string",
-          "minLength": 1
-        },
-        "identifier": {
-          "title": "Identifier",
-          "description": "Distribution identifier",
-          "type": "string"
-        },
-        "description": {
-          "title": "Description",
-          "description": "Human-readable description of the distribution",
-          "type": "string",
-          "minLength": 1
-        },
-        "fileLocation": {
-          "title": " ",
-          "type": "string"
-        },
-        "format": {
-          "title": "Format",
-          "description": "A human-readable description of the file format of a distribution",
-          "type": "string"
-        },
-        "mediaType": {
-          "title": "Media Type",
-          "description": "The machine-readable file format (IANA Media Type or MIME Type) of the distribution’s downloadURL",
-          "type": "string"
-        },
-        "mediaSize": {
-          "title": "Media Size",
-          "description": "The size of the meida file.",
-          "type": "integer"
-        },
-        "downloadURL": {
-          "title": "Download URL",
-          "description": "URL providing direct access to a downloadable file of a dataset",
-          "type": "string",
-          "format": "uri"
-        },
-        "accessURL": {
-          "title": "Access URL",
-          "description": "URL providing indirect access to a dataset",
-          "type": "string",
-          "format": "uri"
-        },
-        "conformsTo": {
-          "title": "Data Standard",
-          "description": "URL providing indirect access to a dataset",
-          "type": "string",
-          "format": "uri"
-        },
-        "describedBy": {
-          "title": "Data Dictionary",
-          "description": "URL to the data dictionary for the distribution found at the downloadURL",
-          "type": "string",
-          "format": "uri"
-        },
-        "describedByType": {
-          "title": "Data Dictionary Type",
-          "description": "The machine-readable file format (IANA Media Type or MIME Type) of the distribution’s describedBy URL",
-          "pattern": "^[a-z]+?$",
-          "type": "string"
-        },
-        "issued": {
-          "title": "Release Date",
-          "description": "Date of formal issuance.",
-          "type": "string",
-          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
-        },
-        "schema": {
-          "title": "Schema",
-          "description": "Ref of https://frictionlessdata.io/schemas/table-schema.json",
-          "type": "object",
-          "properties": {
-            "fields": {
-              "type": "array",
-              "items": {
-                "title": "Table Schema Field",
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "title": "Name",
-                    "description": "A name for this field.",
-                    "type": "string"
-                  },
-                  "title": {
-                    "title": "Title",
-                    "description": "A human-readable title.",
-                    "type": "string"
-                  },
-                  "description": {
-                    "title": "Description",
-                    "description": "A text description. Markdown is encouraged.",
-                    "type": "string"
-                  },
-                  "type": {
-                    "description": "The type for the data.",
-                    "type": "string",
-                    "enum": [
-                      "string",
-                      "integer",
-                      "number",
-                      "boolean",
-                      "object",
-                      "array",
-                      "date",
-                      "time",
-                      "datetime",
-                      "year",
-                      "yearmonth",
-                      "duration",
-                      "geopoint",
-                      "geojson"
-                    ]
-                  },
-                  "format": {
-                    "description": "The format keyword options for `string` are `default`, `email`, `uri`, `binary`, and `uuid`.",
-                    "enum": [
-                      "default",
-                      "email",
-                      "uri",
-                      "binary",
-                      "uuid"
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
This branch should work with https://github.com/GetDKAN/data-catalog-frontend/pull/16
Related ticket: https://github.com/getdkan/dkan2/issues/344

## QA Steps
1. Confirm you can add additional schema fields like publisher.name and distribution.title to the search index `/admin/config/search/search-api/index/dkan/fields`