### PR TITLE
Fix missing class name

### DIFF
--- a/modules/custom/dkan_datastore/src/Drush.php
+++ b/modules/custom/dkan_datastore/src/Drush.php
@@ -136,7 +136,7 @@ class Drush extends DrushCommands {
   public function drop($uuid) {
     try {
       // Load metadata with both identifier and data for this request.
-      drupal_static('dkan_data_dereference_method', ValueReferencer::DEREFERENCE_OUTPUT_REFERENCE_IDS);
+      drupal_static('dkan_data_dereference_method', Dereferencer::DEREFERENCE_OUTPUT_REFERENCE_IDS);
       $this->datastoreService->drop($uuid);
     }
     catch (\Exception $e) {


### PR DESCRIPTION
Noticed the following error while running `drush dkan-datastore:drop <UUID>`:
```
 [error]  Error: Class 'Drupal\dkan_datastore\ValueReferencer' not found in
Drupal\dkan_datastore\Drush->drop() (line 139 of
docroot/profiles/contrib/dkan2/modules/custom/dkan_datastore/src/Drush.php)
#0 [internal function]: Drupal\dkan_datastore\Drush->drop('<UUID>', Array)
```
This PR should address the issue