### PR TITLE
Restore circleci step for installing dkan-tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           name: Install DKTL
           command: |
             cd ~
-            git clone --single-branch --depth 1 --branch 359-composer-merge https://github.com/GetDKAN/dkan-tools.git
+            git clone --single-branch --depth 1 https://github.com/GetDKAN/dkan-tools.git
             chmod 777 ./dkan-tools/bin/dktl
             export PATH=$PATH:~/dkan-tools/bin
             which dktl


### PR DESCRIPTION
Use master branch of dkan-tools. I forgot to remove the adjustment after QA on #373 🤦 