### PR TITLE
Pass right variable to HTML5:parse().

### DIFF
--- a/modules/dkan_metadata_form/src/Drush.php
+++ b/modules/dkan_metadata_form/src/Drush.php
@@ -5,6 +5,7 @@ namespace Drupal\dkan_metadata_form;
 use Drush\Commands\DrushCommands;
 use Masterminds\HTML5;
 use Symfony\Component\Yaml\Yaml;
+use Masterminds\HTML5\Parser\FileInputStream;
 
 /**
  * Drush commands.
@@ -154,9 +155,10 @@ class Drush extends DrushCommands {
     }
 
     $indexFilePath = $this->reactAppBuildDirectoryPath . "/index.html";
+    $input = new FileInputStream($indexFilePath);
 
     $html = new HTML5();
-    $document = $html->parse(file_get_contents($indexFilePath));
+    $document = $html->parse($input);
     $scriptTags = $document->getElementsByTagName("script");
 
     /* @var $scriptTag DOMElement */


### PR DESCRIPTION
Running `dktl drush dkan-metadata-form:sync` produced the following error:

```
 [error]  TypeError: Argument 1 passed to Masterminds\HTML5::parse() must be an instance of Masterminds\HTML5\Parser\InputStream, string given, called in /var/www/docroot/modules/contrib/dkan2/modules/dkan_metadata_form/src/Drush.php on line 159 in Masterminds\HTML5->parse() (line 166 of /var/www/vendor/masterminds/html5/src/HTML5.php) #0 /var/www/docroot/modules/contrib/dkan2/modules/dkan_metadata_form/src/Drush.php(159): Masterminds\HTML5->parse('<!doctype html>...')
```

I'm fixing that here.