### PR TITLE
Update schema to include title for Theme and Keywords array items.

### DIFF
--- a/schema/collections/dataset.json
+++ b/schema/collections/dataset.json
@@ -191,6 +191,7 @@
       "type": "array",
       "items": {
         "type": "string",
+        "title": "Category",
         "minLength": 1
       },
       "uniqueItems": true
@@ -201,6 +202,7 @@
       "type": "array",
       "items": {
         "type": "string",
+        "title": "Tag",
         "minLength": 1
       },
       "minItems": 1


### PR DESCRIPTION
There are accessibility issues on the dkan_metadata_form, according to the standard WCAG AA:

```
This textinput element does not have a name available to an accessibility API. Valid names are: label element, title undefined, aria-label undefined, aria-labelledby undefined.
```

That is happening for every textfield on the Category (theme) and Tags (keyword) array fields.

Looking into the code for the rjsf project, we discovered the issue is actually in the schema we are using, so here I'm updating the schema so we comply with the WCAG AA standard.

This new schema can be tested in the rjsf playground here https://rjsf-team.github.io/react-jsonschema-form/, add this schema and run the HTML Codesniffer tool, you'll see that the error described above is not present anymore for any field in the form.